### PR TITLE
Revamp package layouts and add browse packages page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,6 +45,12 @@
       rel="stylesheet"
     />
 
+    <!-- Bootstrap Icons -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+    />
+
     <!-- Site Styles -->
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -1,22 +1,51 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-FFK75SWM3H"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
       gtag('config', 'G-FFK75SWM3H');
     </script>
 
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-    <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
-    <title>{{ page.title }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-    <!-- Styles -->
+    <!-- Dynamic Title -->
+    <title>
+      {% if page.title %}
+        {{ page.title }} | {{ site.title }}
+      {% else %}
+        {{ site.title }}
+      {% endif %}
+    </title>
+
+    <!-- Meta Description -->
+    {% if page.description %}
+      <meta name="description" content="{{ page.description | strip_html | escape }}" />
+    {% elsif site.description %}
+      <meta name="description" content="{{ site.description | strip_html | escape }}" />
+    {% endif %}
+
+    <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
+
+    <!-- Site Styles -->
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 
     {% seo %}
@@ -28,10 +57,10 @@
         "@type": "Product",
         "name": "{{ page.title }}",
         "image": "{{ page.image }}",
-        "description": "{{ page.description }}",
+        "description": "{{ page.description | strip_html | escape }}",
         "offers": {
           "@type": "Offer",
-          "url": "{{ page.url }}",
+          "url": "{{ page.url | absolute_url }}",
           "priceCurrency": "USD",
           "price": "{{ page.price }}"
         }
@@ -39,107 +68,195 @@
     </script>
   </head>
 
-  <body class="bg-info text-dark">
+  <body class="site-body package-page">
     <!-- Header -->
     <header>
       {% include header.html %}
     </header>
 
     <!-- Main Content -->
-    <main>
-      <div class="container mt-3">
-        <!-- Breadcrumb 
-        <nav aria-label="breadcrumb" class="mb-4">
-          <ol class="breadcrumb bg-white rounded shadow-sm px-4 py-2">
-            <li class="breadcrumb-item">Packages</li>
-            <li class="breadcrumb-item">{{ page.category }}</li>
-            <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
-          </ol>
-        </nav> -->
+    <main class="site-main">
+      {% assign package_category = page.category | default: 'Audio' | capitalize %}
+      {% assign description_excerpt = page.description | strip_html | truncate: 220 %}
 
-        <!-- Product Header -->
-        <section class="text-center my-5">
-          <h1 class="display-4 fw-bold text-primary">{{ page.title }}</h1>
-          <img src="{{ page.image }}" class="img-fluid rounded shadow-sm my-4" alt="{{ page.title }}" width="700" height="500">
-          <p class="lead text-muted">{{ page.description }}</p>
+      <!-- Hero -->
+      <section class="package-hero hero-section text-white position-relative overflow-hidden">
+        <div class="hero-glow"></div>
+        <div class="container py-5 py-lg-6">
+          <div class="row align-items-center g-5">
+            <div class="col-lg-6">
+              <span class="badge badge-soft-light text-uppercase">{{ package_category }} Package</span>
+              <h1 class="display-4 fw-bold mt-4 text-white">{{ page.title }}</h1>
+              <p class="lead text-white-50 mb-4">{{ description_excerpt }}</p>
 
-          <!-- Centered Price Section -->
-          <div class="my-4 text-center">
-            <div class="d-inline-block bg-primary text-white px-4 py-2 rounded shadow-sm">
-              <span class="h3 fw-bold">${{ page.price }}</span>
-              <span class="h5 fw-bold">/day</span>
-            </div>
-          </div>
-        </section>
-
-        <!-- Feature Cards -->
-        <div class="row row-cols-1 row-cols-md-2 g-4">
-          <!-- Includes -->
-          <div class="col">
-            <div class="card h-100 shadow-sm">
-              <div class="card-body">
-                <h5 class="card-title text-primary">Includes</h5>
-                <ul class="list-unstyled">
-                  {% for inc in page.items_included %}
-                    <li>✔️ {{ inc }}</li>
-                  {% endfor %}
-                </ul>
+              <div class="d-flex flex-wrap gap-3 align-items-center">
+                <div class="price-pill shadow-lg">
+                  <span class="price-amount">${{ page.price }}</span>
+                  <span class="price-period">per day</span>
+                </div>
+                <a href="/about/contact/" class="btn btn-gradient btn-lg shadow-lg">Reserve this package</a>
+                <a href="tel:+17072268726" class="btn btn-outline-light btn-lg">
+                  <i class="bi bi-telephone me-2"></i>Call us
+                </a>
               </div>
-            </div>
-          </div>
 
-          <!-- Features -->
-          <div class="col">
-            <div class="card h-100 shadow-sm">
-              <div class="card-body">
-                <h5 class="card-title text-primary">Features</h5>
-                <ul class="list-unstyled">
-                  {% for feature in page.features %}
-                    <li>⚙️ {{ feature }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
+              <ul class="package-stats list-unstyled d-flex flex-wrap gap-4 mt-4 mb-0">
+                <li class="stat-item">
+                  <span class="stat-label">Power Output</span>
+                  <span class="stat-value">
+                    {% if page.system_power %}
+                      {{ page.system_power }}W
+                    {% else %}
+                      Custom-tuned
+                    {% endif %}
+                  </span>
+                </li>
+                <li class="stat-item">
+                  <span class="stat-label">Service Area</span>
+                  <span class="stat-value">Bay Area &amp; Sacramento</span>
+                </li>
+                <li class="stat-item">
+                  <span class="stat-label">Delivery &amp; Setup</span>
+                  <span class="stat-value">Included</span>
+                </li>
+              </ul>
             </div>
-          </div>
 
-          <!-- Perfect For -->
-          <div class="col">
-            <div class="card h-100 shadow-sm">
-              <div class="card-body">
-                <h5 class="card-title text-primary">Perfect For</h5>
-                <ul class="list-unstyled">
-                  {% for customers in page.perfect_for %}
-                    <li>🎯 {{ customers }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          <!-- Upgrades -->
-          <div class="col">
-            <div class="card h-100 shadow-sm">
-              <div class="card-body">
-                <h5 class="card-title text-primary">Optional Upgrades</h5>
-                <ul class="list-unstyled">
-                  {% for upgrade in page.upgrades %}
-                    <li> <i class="bi bi-arrow-up-circle me-2 text-success"></i> {{ upgrade }}</li>
-                  {% endfor %}
-                </ul>
+            <div class="col-lg-6">
+              <div class="package-media shadow-lg">
+                <img src="{{ page.image }}" alt="{{ page.title }}" class="img-fluid rounded-4" />
+                {% if page.items_included %}
+                  <div class="floating-card shadow-lg">
+                    <p class="mb-2 fw-semibold text-uppercase small text-muted">What's included</p>
+                    <ul class="list-unstyled mb-0 small text-muted">
+                      {% for inc in page.items_included limit: 3 %}
+                        <li><i class="bi bi-check-circle-fill me-2 text-success"></i>{{ inc }}</li>
+                      {% endfor %}
+                      {% if page.items_included and page.items_included.size > 3 %}
+                        <li class="text-primary fw-semibold mt-2">+ more essentials on the full list</li>
+                      {% endif %}
+                    </ul>
+                  </div>
+                {% endif %}
               </div>
             </div>
           </div>
         </div>
+      </section>
 
-        <!-- Spacer at the bottom for footer -->
-        <div class="my-5"></div>
+      <!-- Overview -->
+      <section class="section-spacing package-overview">
+        <div class="container">
+          <div class="row g-4 align-items-start">
+            <div class="col-lg-8">
+              <article class="content-card shadow-sm h-100">
+                <h2 class="h3 mb-3">Package overview</h2>
+                <div class="text-muted fs-5">
+                  {{ page.description | markdownify }}
+                </div>
+              </article>
+            </div>
+            <div class="col-lg-4">
+              <aside class="content-card highlight-card shadow-sm h-100">
+                <h3 class="h5 fw-bold">Need a custom setup?</h3>
+                <p class="text-muted">Tell us about your venue, audience size, and vibe. We'll tune the package to match your event.</p>
+                <ul class="list-unstyled text-muted small mb-4">
+                  <li class="mb-2"><i class="bi bi-lightning-charge me-2 text-primary"></i>White-glove delivery &amp; strike</li>
+                  <li class="mb-2"><i class="bi bi-headset me-2 text-primary"></i>On-call audio engineer support</li>
+                  <li><i class="bi bi-check2-circle me-2 text-primary"></i>Optional rehearsal or sound check add-ons</li>
+                </ul>
+                <a href="/about/contact/" class="btn btn-gradient w-100">Plan my event</a>
+              </aside>
+            </div>
+          </div>
+        </div>
+      </section>
 
-      </div>
+      <!-- Details Grid -->
+      <section class="section-spacing pt-0">
+        <div class="container">
+          <div class="row g-4">
+            {% if page.items_included %}
+              <div class="col-md-6 col-xl-3">
+                <div class="content-card h-100 shadow-sm">
+                  <div class="card-icon text-primary"><i class="bi bi-box-seam"></i></div>
+                  <h3 class="h5">In the case</h3>
+                  <ul class="package-list mb-0">
+                    {% for inc in page.items_included %}
+                      <li>{{ inc }}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endif %}
+
+            {% if page.features %}
+              <div class="col-md-6 col-xl-3">
+                <div class="content-card h-100 shadow-sm">
+                  <div class="card-icon text-primary"><i class="bi bi-stars"></i></div>
+                  <h3 class="h5">Standout features</h3>
+                  <ul class="package-list mb-0">
+                    {% for feature in page.features %}
+                      <li>{{ feature }}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endif %}
+
+            {% if page.perfect_for %}
+              <div class="col-md-6 col-xl-3">
+                <div class="content-card h-100 shadow-sm">
+                  <div class="card-icon text-primary"><i class="bi bi-people"></i></div>
+                  <h3 class="h5">Perfect for</h3>
+                  <ul class="package-list mb-0">
+                    {% for audience in page.perfect_for %}
+                      <li>{{ audience }}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endif %}
+
+            {% if page.upgrades %}
+              <div class="col-md-6 col-xl-3">
+                <div class="content-card h-100 shadow-sm">
+                  <div class="card-icon text-primary"><i class="bi bi-arrow-up-circle"></i></div>
+                  <h3 class="h5">Optional upgrades</h3>
+                  <ul class="package-list mb-0">
+                    {% for upgrade in page.upgrades %}
+                      <li>{{ upgrade }}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section class="section-spacing pt-0">
+        <div class="container">
+          <div class="cta-banner shadow-lg">
+            <div>
+              <span class="badge badge-soft-primary">You're covered</span>
+              <h2 class="h3 fw-bold mt-3">Full-service rentals with concierge support.</h2>
+              <p class="text-muted mb-0">We handle delivery, setup, onsite checks, and 24/7 tech support so you can focus on your guests.</p>
+            </div>
+            <div class="d-flex flex-column flex-sm-row gap-3">
+              <a href="/about/contact/" class="btn btn-gradient btn-lg">Check availability</a>
+              <a href="mailto:bookings@vproaudio.rentals" class="btn btn-outline-primary btn-lg">Email our team</a>
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
 
     <!-- Footer -->
     {% include footer.html %}
 
+    <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
   </body>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -375,6 +375,211 @@ h1, h2, h3, h4, h5, h6 {
   box-shadow: 0 12px 24px rgba(20, 26, 54, 0.08);
 }
 
+/* ============================================================
+   Package & Packages Pages
+   ============================================================ */
+.package-page {
+  background: linear-gradient(180deg, #f6f8fb 0%, #ffffff 80%);
+}
+
+.price-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.9rem 1.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.price-pill .price-amount {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.price-pill .price-period {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.package-stats .stat-item {
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+}
+
+.package-stats .stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.package-stats .stat-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.package-media {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1.25rem;
+}
+
+.package-media img {
+  border-radius: 1.25rem;
+}
+
+.package-media .floating-card {
+  position: absolute;
+  bottom: 18px;
+  right: 18px;
+}
+
+.content-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  padding: 2.25rem;
+  border: 1px solid rgba($primary, 0.08);
+}
+
+.highlight-card {
+  background: linear-gradient(180deg, rgba($primary, 0.05) 0%, rgba($primary, 0.01) 100%);
+}
+
+.card-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba($primary, 0.1);
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.package-list {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+
+.package-list li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 0.6rem;
+  color: $secondary;
+  font-size: 0.98rem;
+}
+
+.package-list li::before {
+  content: '\2713';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-weight: 700;
+  color: $primary;
+}
+
+.cta-banner,
+.microphone-highlight {
+  background: #fff;
+  border-radius: 1.75rem;
+  padding: 2.5rem 3rem;
+  border: 1px solid rgba($primary, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .cta-banner,
+  .microphone-highlight {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.packages-hero-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  padding: 2.25rem;
+  border: 1px solid rgba($primary, 0.1);
+  box-shadow: 0 26px 44px rgba(20, 26, 54, 0.1);
+}
+
+.package-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  border: 1px solid rgba($primary, 0.08);
+  box-shadow: 0 18px 36px rgba(20, 26, 54, 0.08);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.package-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 60px rgba(20, 26, 54, 0.12);
+}
+
+.package-card__media {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.25rem;
+  background: rgba($primary, 0.04);
+}
+
+.package-card__media img {
+  width: 100%;
+  object-fit: cover;
+}
+
+.package-card__badge {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  background: rgba(255, 255, 255, 0.85);
+  color: $primary;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.package-card__body {
+  flex: 1 1 auto;
+}
+
+.package-card__footer .price {
+  font-size: 1.35rem;
+}
+
+.feature-summary {
+  min-height: 100%;
+}
+
+/* Utility spacing */
+@media (min-width: 992px) {
+  .py-lg-6 {
+    padding-top: 5.5rem !important;
+    padding-bottom: 5.5rem !important;
+  }
+}
+
 .fade-in {
   opacity: 0;
   transform: translateY(20px);

--- a/microphones.md
+++ b/microphones.md
@@ -4,31 +4,96 @@ title: Microphone Packages
 permalink: /packages/audio/microphones/
 ---
 
-<div class="container py-5">
-
-  <!-- Page Header -->
-  <section class="text-center mb-5">
-    <h1 class="display-4 fw-bold text-primary">Microphone Packages</h1>
-    <p class="lead text-muted">Professional microphones for every occasion — live performances, events, podcasts, and more.</p>
-  </section>
-
-  <!-- Microphone Package Cards -->
-  <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-    {% for mic in site.data.microphones %}
-    <div class="col">
-      <div class="card h-100 shadow-sm">
-        <img src="{{ mic.image }}" class="card-img-top" alt="{{ mic.title }}">
-        <div class="card-body">
-          <h5 class="card-title text-primary">{{ mic.title }}</h5>
-          <p class="card-text text-muted">{{ mic.description }}</p>
+<section class="packages-hero hero-section position-relative overflow-hidden text-white">
+  <div class="hero-glow"></div>
+  <div class="container py-5 py-lg-6">
+    <div class="row align-items-center g-5">
+      <div class="col-lg-7">
+        <span class="badge badge-soft-light text-uppercase">Microphone rentals</span>
+        <h1 class="display-4 fw-bold mt-4 text-white">Crystal-clear vocals, speeches, and recordings.</h1>
+        <p class="lead text-white-50">From handheld wireless mics to studio staples, our curated kits include stands, cables, and expert setup so every word lands with impact.</p>
+        <div class="d-flex flex-wrap gap-3 mt-4">
+          <a href="/about/contact/" class="btn btn-gradient btn-lg shadow-lg">Build a microphone kit</a>
+          <a href="mailto:bookings@vproaudio.rentals" class="btn btn-outline-light btn-lg">Email our engineers</a>
         </div>
-        <div class="card-footer text-center bg-white">
-          <span class="h5 fw-bold">${{ mic.price }}/day</span>
+      </div>
+      <div class="col-lg-5">
+        <div class="packages-hero-card shadow-lg">
+          <p class="mb-3 text-uppercase small fw-semibold text-muted">Included with every rental</p>
+          <ul class="list-unstyled text-muted mb-0">
+            <li class="mb-2"><i class="bi bi-gear-wide-connected me-2 text-primary"></i>Fresh batteries, cables, and stands</li>
+            <li class="mb-2"><i class="bi bi-broadcast-pin me-2 text-primary"></i>Frequency coordination for your venue</li>
+            <li><i class="bi bi-headset me-2 text-primary"></i>On-call support throughout your event</li>
+          </ul>
         </div>
       </div>
     </div>
-    {% endfor %}
   </div>
+</section>
 
-</div>
+<section class="section-spacing">
+  <div class="container">
+    <div class="row g-4 mb-5">
+      <div class="col-md-4">
+        <div class="content-card feature-summary h-100 shadow-sm">
+          <div class="card-icon text-primary"><i class="bi bi-mic"></i></div>
+          <h2 class="h5">Wireless expertise</h2>
+          <p class="text-muted mb-0">Tour-tested Shure systems with pre-programmed channels to avoid interference and feedback.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="content-card feature-summary h-100 shadow-sm">
+          <div class="card-icon text-primary"><i class="bi bi-plug"></i></div>
+          <h2 class="h5">Plug-and-play ready</h2>
+          <p class="text-muted mb-0">Delivered with mixers, speakers, or interfaces to integrate seamlessly with your package.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="content-card feature-summary h-100 shadow-sm">
+          <div class="card-icon text-primary"><i class="bi bi-people"></i></div>
+          <h2 class="h5">Tailored recommendations</h2>
+          <p class="text-muted mb-0">We'll match microphones to your performers—singers, celebrants, speakers, or podcasters.</p>
+        </div>
+      </div>
+    </div>
 
+    <div class="row g-4">
+      {% for mic in site.data.microphones %}
+        <div class="col-12 col-md-6 col-lg-4">
+          <article class="package-card h-100">
+            <div class="package-card__media">
+              <img src="{{ mic.image }}" alt="{{ mic.title }}" class="img-fluid rounded-4" />
+            </div>
+            <div class="package-card__body">
+              <h3 class="h4">{{ mic.title }}</h3>
+              <p class="text-muted">{{ mic.description }}</p>
+            </div>
+            <div class="package-card__footer d-flex align-items-center justify-content-between">
+              <div>
+                <span class="price fw-bold">${{ mic.price }}</span>
+                <span class="text-muted">/day</span>
+              </div>
+              <a href="/about/contact/" class="btn btn-outline-primary btn-sm">Add to package</a>
+            </div>
+          </article>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="section-spacing pt-0">
+  <div class="container">
+    <div class="cta-banner shadow-lg">
+      <div>
+        <span class="badge badge-soft-primary">Soundcheck ready</span>
+        <h2 class="h3 fw-bold mt-3">Reserve your microphones with your rental package.</h2>
+        <p class="text-muted mb-0">Share your run-of-show and we’ll have the right mics labeled, tested, and ready to hand off.</p>
+      </div>
+      <div class="d-flex flex-column flex-sm-row gap-3">
+        <a href="/about/contact/" class="btn btn-gradient btn-lg">Request availability</a>
+        <a href="tel:+17072268726" class="btn btn-outline-primary btn-lg">Talk with an audio tech</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/packages/index.html
+++ b/packages/index.html
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Packages
+permalink: /packages/
+---
+
+<section class="packages-hero hero-section position-relative overflow-hidden text-white">
+  <div class="hero-glow"></div>
+  <div class="container py-5 py-lg-6">
+    <div class="row align-items-center g-5">
+      <div class="col-lg-7">
+        <span class="badge badge-soft-light text-uppercase">Browse our rentals</span>
+        <h1 class="display-4 fw-bold mt-4 text-white">Curated packages for unforgettable events.</h1>
+        <p class="lead text-white-50">High-impact audio and visual setups tailored for weddings, celebrations, markets, and corporate experiences. Choose a ready-to-go package or let us customize one for you.</p>
+        <div class="d-flex flex-wrap gap-3 mt-4">
+          <a href="/about/contact/" class="btn btn-gradient btn-lg shadow-lg">Talk to a specialist</a>
+          <a href="tel:+17072268726" class="btn btn-outline-light btn-lg">Call (707) 226-8726</a>
+        </div>
+      </div>
+      <div class="col-lg-5">
+        <div class="packages-hero-card shadow-lg">
+          <p class="mb-3 text-uppercase small fw-semibold text-muted">Why clients choose us</p>
+          <ul class="list-unstyled text-muted mb-0">
+            <li class="mb-2"><i class="bi bi-truck me-2 text-primary"></i>White-glove delivery, setup, and strike</li>
+            <li class="mb-2"><i class="bi bi-headset me-2 text-primary"></i>24/7 tech support from touring engineers</li>
+            <li><i class="bi bi-check-circle me-2 text-primary"></i>Flexible day-rate rentals with no surprise fees</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-spacing">
+  <div class="container">
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-5">
+      <div>
+        <span class="badge badge-soft-primary">All packages</span>
+        <h2 class="h1 fw-bold mt-3 mb-0">Ready-to-rent audio &amp; visual solutions</h2>
+      </div>
+      <p class="text-muted mb-0">Every package includes professional cabling, stands, and on-call support. Need adjustments? We'll tailor the gear list for your venue.</p>
+    </div>
+
+    <div class="row g-4">
+      {% assign sorted_packages = site.packages | sort: 'title' %}
+      {% for package in sorted_packages %}
+        <div class="col-12 col-md-6 col-xl-4">
+          <article class="package-card h-100">
+            <div class="package-card__media">
+              <img src="{{ package.image }}" alt="{{ package.title }}" class="img-fluid rounded-4" />
+              <span class="package-card__badge">{{ package.category | capitalize }}</span>
+            </div>
+            <div class="package-card__body">
+              <h3 class="h4">
+                <a href="{{ package.url | relative_url }}" class="stretched-link">{{ package.title }}</a>
+              </h3>
+              <p class="text-muted">{{ package.description | strip_html | truncate: 160 }}</p>
+            </div>
+            <div class="package-card__footer d-flex align-items-center justify-content-between">
+              <div>
+                <span class="price fw-bold">${{ package.price }}</span>
+                <span class="text-muted">/day</span>
+              </div>
+              <a href="{{ package.url | relative_url }}" class="btn btn-outline-primary btn-sm">View details</a>
+            </div>
+          </article>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="section-spacing pt-0">
+  <div class="container">
+    <div class="microphone-highlight shadow-lg">
+      <div>
+        <span class="badge badge-soft-primary">Need more mics?</span>
+        <h2 class="h3 fw-bold mt-3">Microphone packages for vocals, instruments, and podcasts.</h2>
+        <p class="text-muted mb-0">Pair any rental with handheld, headset, or studio-grade microphones curated for clean, reliable performances.</p>
+      </div>
+      <div class="d-flex flex-column flex-sm-row gap-3">
+        <a href="/packages/audio/microphones/" class="btn btn-gradient btn-lg">Explore microphone rentals</a>
+        <a href="mailto:bookings@vproaudio.rentals" class="btn btn-outline-primary btn-lg">Ask about add-ons</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-spacing pt-0">
+  <div class="container">
+    <div class="cta-banner shadow-lg">
+      <div>
+        <span class="badge badge-soft-primary">Let's plan it</span>
+        <h2 class="h3 fw-bold mt-3">Tell us about your event and we'll handle the sound.</h2>
+        <p class="text-muted mb-0">Send the timeline, venue size, and vibe. We'll confirm availability within one business day.</p>
+      </div>
+      <div class="d-flex flex-column flex-sm-row gap-3">
+        <a href="/about/contact/" class="btn btn-gradient btn-lg">Request a custom quote</a>
+        <a href="https://cal.com/vproaudio/consult" class="btn btn-outline-primary btn-lg" target="_blank" rel="noopener">Book a consult call</a>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- redesign the collection package layout with a hero, feature grid, and booking calls-to-action aligned with the homepage styling
- enhance the microphone packages page with the same elevated presentation and supporting service highlights
- add a dedicated browse packages page and supporting styles, including bootstrap icon support for consistent visuals across the site

## Testing
- bundle exec jekyll build *(fails: `jekyll` command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b28cd504832c90b224de6cbaba2c