### PR TITLE
Adjust package imagery background to match theme

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -538,7 +538,11 @@ h1, h2, h3, h4, h5, h6 {
   position: relative;
   overflow: hidden;
   border-radius: 1.25rem;
-  background: rgba($primary, 0.04);
+  background: linear-gradient(135deg, rgba($primary, 0.08) 0%, rgba($info, 0.95) 100%);
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .package-card__media img {


### PR DESCRIPTION
## Summary
- update the package card media background with a gradient that aligns with the site's primary and info colors
- add spacing and centering so package and microphone imagery sits against the new themed backdrop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b9ac646c832c93859b9fa451ef71