### PR TITLE
Remove Brands entry from About dropdown

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -24,7 +24,5 @@
   dropdown:
     - title: FAQs
       url: /about/faqs/
-    - title: Brands
-      url: /about/brands/
     - title: Contact
       url: /about/contact/


### PR DESCRIPTION
## Summary
- remove the Brands item from the About navigation dropdown now that the page is redundant

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d3709094832c8f7f30256641cd10