### PR TITLE
Adjust body padding for fixed header

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -727,6 +727,10 @@ footer.site-footer {
 }
 
 /* Adjust for fixed-top navbar height */
+body {
+  padding-top: 96px;
+}
+
 @media (max-width: 991.98px) {
   body {
     padding-top: 80px;


### PR DESCRIPTION
## Summary
- add global top padding to body to accommodate the fixed navigation bar
- retain a smaller offset on mobile viewports to match the navbar height

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d4f36aa0832cb9cd4f1e3da67d87