### PR TITLE
Improve privacy policy hero contrast

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1015,6 +1015,26 @@ body {
 /* ============================================================
    Privacy Policy Page Enhancements
    ============================================================ */
+.privacy-hero {
+  background: linear-gradient(140deg, #0c183f 0%, #1a2d73 55%, #2946a1 100%);
+  box-shadow: inset 0 -40px 120px rgba(12, 20, 50, 0.55);
+}
+
+.privacy-hero::before {
+  background: radial-gradient(circle at top left, rgba(92, 132, 255, 0.55), transparent 70%);
+  opacity: 0.85;
+}
+
+.privacy-hero .hero-eyebrow {
+  background: rgba(255, 255, 255, 0.24) !important;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.privacy-hero .display-4,
+.privacy-hero .lead {
+  text-shadow: 0 12px 32px rgba(5, 8, 24, 0.45);
+}
+
 .letter-spacing-wide {
   letter-spacing: 0.18em;
 }

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -5,7 +5,7 @@ permalink: /privacy-policy/
 description: Learn how VANS Pro Audio Rentals collects, protects, and uses your personal information when you engage with our services.
 ---
 
-<section class="hero-section text-white py-5 py-lg-5 position-relative overflow-hidden">
+<section class="hero-section privacy-hero text-white py-5 py-lg-5 position-relative overflow-hidden">
   <div class="container py-4 py-lg-5 position-relative">
     <span class="badge badge-soft-light hero-eyebrow mb-3">Privacy Policy</span>
     <div class="row align-items-center gy-4">


### PR DESCRIPTION
## Summary
- add a dedicated privacy hero gradient and supporting styling to improve legibility against the background
- apply the new hero class to the privacy policy page so the header stands out more clearly

## Testing
- ⚠️ `bundle install` *(fails: rubygems.org returned 403 Forbidden, preventing local Jekyll build)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d62c0744832c9f5a17bb55bdf151