### PR TITLE
Update FAQ service hours to 10 AM–10 PM PT daily

### DIFF
--- a/faqs.html
+++ b/faqs.html
@@ -159,16 +159,8 @@ permalink: /about/faqs/
               </div>
               <div class="d-grid gap-2 small text-muted">
                 <div class="d-flex justify-content-between">
-                  <span>Monday – Friday</span>
-                  <strong>9:00 AM – 6:00 PM PT</strong>
-                </div>
-                <div class="d-flex justify-content-between">
-                  <span>Saturday</span>
-                  <strong>10:00 AM – 2:00 PM PT</strong>
-                </div>
-                <div class="d-flex justify-content-between">
-                  <span>Sunday</span>
-                  <strong>By appointment</strong>
+                  <span>Monday – Sunday</span>
+                  <strong>10:00 AM – 10:00 PM PT</strong>
                 </div>
               </div>
               <p class="small text-muted mb-0">Need support outside these hours? Let us know—we often accommodate early load-ins


### PR DESCRIPTION
## Summary
- update the service hours callout in the FAQs to reflect availability from 10:00 AM to 10:00 PM PT every day of the week

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d8d69f6a48832c8b42dbdcbcf73add