### PR TITLE
Adjust privacy policy header contrast

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,7 @@
     {% seo %}
   </head>
 
-  <body class="site-body">
+  <body class="site-body{% if page.body_class %} {{ page.body_class }}{% endif %}">
     <!-- Header -->
     <header>
       {% include header.html %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -112,6 +112,49 @@ h1, h2, h3, h4, h5, h6 {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(20,26,54,0.85)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
+.privacy-policy-page {
+  .glassy-nav {
+    background: rgba(16, 21, 45, 0.85);
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .navbar-brand {
+    color: #fff;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .brand-title {
+    color: #fff;
+  }
+
+  .brand-tagline {
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .navbar-nav .nav-link {
+    color: rgba(255, 255, 255, 0.85);
+
+    &:hover,
+    &:focus,
+    &.active {
+      color: #fff;
+      background-color: rgba(255, 255, 255, 0.12);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+    }
+  }
+
+  .navbar-toggler {
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  }
+
+  .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255,255,255,0.9)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  }
+}
+
 /* ============================================================
    Buttons & Badges
    ============================================================ */

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -3,6 +3,7 @@ layout: default
 title: Privacy Policy
 permalink: /privacy-policy/
 description: Learn how VANS Pro Audio Rentals collects, protects, and uses your personal information when you engage with our services.
+body_class: privacy-policy-page
 ---
 
 <section class="hero-section text-white py-5 py-lg-5 position-relative overflow-hidden">


### PR DESCRIPTION
## Summary
- allow layouts to append an optional body class from page front matter for page-specific styling
- override the privacy policy navigation styling so the header text renders white against the dark hero

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d8d7663a20832c9684857ccfbd4ddb