### PR TITLE
Fix missing front matter delimiter on contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,3 +1,4 @@
+---
 layout: default
 title: About - Contact
 permalink: /about/contact/


### PR DESCRIPTION
## Summary
- add the opening front matter delimiter to contact.html so Jekyll can generate the page

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d8a97464832cb0949ae595116ad7