### PR TITLE
Fix EmailJS integration on contact page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,7 +72,7 @@
     {% include footer.html %}
 
     <!-- EmailJS -->
-    <script src="https://cdn.emailjs.com/dist/email.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"></script>
 
     <!-- Bootstrap Bundle JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -280,7 +280,9 @@ permalink: /about/contact/
 <!-- EmailJS and Validation Script -->
 <script>
 (function(){
-    emailjs.init("8g9ogIfKnECKwhPCN");
+    emailjs.init({
+        publicKey: "8g9ogIfKnECKwhPCN"
+    });
 })();
 
 function submitForm() {
@@ -315,7 +317,7 @@ function submitForm() {
     }
 
     if (isValid) {
-        emailjs.sendForm("service_ilnhxr9", "template_t1xv5a8", "contactForm")
+        emailjs.sendForm("service_ilnhxr9", "template_t1xv5a8", "#contactForm")
             .then(function(responseResult) {
                 response.innerHTML = '<div class="alert alert-success">Thank you for contacting us. Your message has been sent!</div>';
                 document.getElementById("contactForm").reset();


### PR DESCRIPTION
## Summary
- update the EmailJS CDN script to the supported @emailjs/browser package
- initialize EmailJS with the public key object syntax and send the form using the ID selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8da3b15bc832c8f8ef5dee6eac3b0