### PR TITLE
Include form metadata in EmailJS message

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -292,6 +292,8 @@ document.addEventListener("DOMContentLoaded", function () {
 function submitForm() {
     const name = document.getElementById("user_name");
     const email = document.getElementById("user_email");
+    const eventDate = document.getElementById("event_date");
+    const supportType = document.getElementById("support_type");
     const message = document.getElementById("message");
     const response = document.getElementById("responseMessage");
     const submitButton = document.getElementById("contactSubmit");
@@ -336,8 +338,23 @@ function submitForm() {
     const originalText = submitButton.innerHTML;
     submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Sending...';
 
+    const originalMessageValue = message.value;
+    const composedMessageParts = [
+        `Support type: ${supportType.value}`
+    ];
+
+    if (eventDate.value.trim()) {
+        composedMessageParts.push(`Event date: ${eventDate.value.trim()}`);
+    }
+
+    composedMessageParts.push('', originalMessageValue);
+    message.value = composedMessageParts.join('\n');
+
+    let didSucceed = false;
+
     emailjs.sendForm("service_ilnhxr9", "template_t1xv5a8", "#contactForm")
         .then(function() {
+            didSucceed = true;
             response.innerHTML = '<div class="alert alert-success">Thank you for contacting us. Your message has been sent!</div>';
             document.getElementById("contactForm").reset();
         })
@@ -346,6 +363,9 @@ function submitForm() {
             response.innerHTML = '<div class="alert alert-danger">Oops! Something went wrong while sending your message. Please try again later or email us directly at <a href="mailto:bookings@vproaudio.rentals" class="alert-link">bookings@vproaudio.rentals</a>.</div>';
         })
         .finally(function() {
+            if (!didSucceed) {
+                message.value = originalMessageValue;
+            }
             submitButton.disabled = false;
             submitButton.innerHTML = originalText;
         });


### PR DESCRIPTION
## Summary
- append the selected support type and optional event date to the message before sending through EmailJS
- restore the original message text if the send attempt fails so the user input stays intact

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d8de13cfe4832c91b94265564963a0