### PR TITLE
Align hero sections across site pages

### DIFF
--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -85,7 +85,7 @@
         <div class="container py-5 py-lg-6">
           <div class="row align-items-center g-5">
             <div class="col-lg-6">
-              <span class="badge badge-soft-light text-uppercase">{{ package_category }} Package</span>
+              <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">{{ package_category }} Package</span>
               <h1 class="display-4 fw-bold mt-4 text-white">{{ page.title }}</h1>
               <p class="lead text-white-50 mb-4">{{ description_excerpt }}</p>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -288,6 +288,24 @@ h1, h2, h3, h4, h5, h6 {
   color: $secondary;
 }
 
+.brands-hero-media {
+  backdrop-filter: blur(12px);
+}
+
+.brands-hero-media .brand-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.brands-hero-media .brand-preview-grid img {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.85rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
 /* ============================================================
    Sections
    ============================================================ */
@@ -414,7 +432,6 @@ h1, h2, h3, h4, h5, h6 {
    ============================================================ */
 .faq-hero {
   position: relative;
-  background: linear-gradient(135deg, rgba($primary, 0.98) 0%, #1d2550 45%, #3b2f6c 100%);
   color: #fff;
 }
 

--- a/brands.html
+++ b/brands.html
@@ -4,11 +4,52 @@ title: About - Brands
 permalink: /about/brands/
 ---
 
-<!-- Header Section -->
-<div class="container py-5 mt-5 text-center">
-  <h1 class="display-4 fw-bold text-primary">Equipment Brands</h1>
-  <p class="lead text-muted">We trust and stock only the following top-tier equipment brands.</p>
-</div>
+<!-- Hero Section -->
+<section class="hero-section brands-hero text-white position-relative overflow-hidden">
+  <div class="hero-glow"></div>
+  <div class="container py-5 py-lg-6">
+    <div class="row align-items-center g-5">
+      <div class="col-lg-7">
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">Gear we trust</span>
+        <h1 class="display-4 fw-bold mt-4 text-white">Equipment brands we rely on every night.</h1>
+        <p class="lead text-white-50 mb-4">From wireless microphones to festival-ready speakers, every brand in our warehouse is tour-tested and supported by our engineering team.</p>
+        <div class="d-flex flex-column flex-sm-row gap-3">
+          <a href="/packages" class="btn btn-gradient btn-lg shadow-lg">Explore rental packages</a>
+          <a href="/about/contact/" class="btn btn-outline-light btn-lg">Request a gear checklist</a>
+        </div>
+        <div class="d-flex flex-wrap gap-4 mt-5 hero-stats">
+          <div class="stat">
+            <span class="stat-value">25+</span>
+            <span class="stat-label">Premium manufacturers</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value">100%</span>
+            <span class="stat-label">Maintained in-house</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value">Same-day</span>
+            <span class="stat-label">Tech support</span>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-5">
+        <div class="hero-media shadow-lg p-4 brands-hero-media">
+          <p class="mb-3 fw-semibold text-uppercase small text-muted">Featured manufacturers</p>
+          <div class="brand-preview-grid">
+            <img src="/assets/images/shure.png" alt="Shure" class="img-fluid">
+            <img src="/assets/images/mackie.png" alt="Mackie" class="img-fluid">
+            <img src="/assets/images/ev.png" alt="Electro-Voice" class="img-fluid">
+            <img src="/assets/images/yamaha.png" alt="Yamaha" class="img-fluid">
+          </div>
+          <div class="d-flex align-items-center gap-3 mt-4">
+            <i class="bi bi-shield-check text-primary fs-4"></i>
+            <p class="text-muted mb-0">Delivered calibrated, cleaned, and ready for your stage or storefront.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
 <!-- Brands Grid -->
 <div class="container pb-5">

--- a/contact.html
+++ b/contact.html
@@ -6,30 +6,7 @@ permalink: /about/contact/
 
 <style>
     .contact-hero {
-        background: radial-gradient(circle at top left, rgba(25, 135, 84, 0.25), transparent 60%),
-                    radial-gradient(circle at bottom right, rgba(25, 135, 84, 0.4), transparent 55%),
-                    linear-gradient(135deg, #0f172a, #1e293b);
-        color: #f8fafc;
         position: relative;
-        overflow: hidden;
-    }
-
-    .contact-hero::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background-image: linear-gradient(120deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.02) 100%);
-        mix-blend-mode: screen;
-        opacity: 0.5;
-        pointer-events: none;
-    }
-
-    .contact-hero .badge-soft {
-        background: rgba(248, 250, 252, 0.2);
-        color: #f8fafc;
-        border-radius: 999px;
-        padding: 0.5rem 1.25rem;
-        backdrop-filter: blur(4px);
     }
 
     .contact-hero h1 {
@@ -114,34 +91,34 @@ permalink: /about/contact/
     }
 </style>
 
-<section class="contact-hero py-5">
-    <div class="container position-relative">
+<section class="hero-section contact-hero text-white position-relative overflow-hidden">
+    <div class="hero-glow"></div>
+    <div class="container py-5 py-lg-6 position-relative">
         <div class="row align-items-center g-5">
-            <div class="col-lg-7">
-                <span class="badge-soft mb-3 d-inline-flex align-items-center gap-2">
-                    <i class="bi bi-stars"></i>
-                    Premium support for every event
-                </span>
-                <h1 class="fw-bold mb-3">Let’s bring your next production to life</h1>
+            <div class="col-lg-6">
+                <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">Concierge audio support</span>
+                <h1 class="fw-bold mt-4 mb-3">Let’s bring your next production to life</h1>
                 <p class="lead mb-4">Tell us about your goals, your gear list, or the experience you want to create. Our audio experts respond within one business day with tailored recommendations and pricing.</p>
-                <div class="d-flex flex-wrap gap-3">
-                    <div class="d-flex align-items-center gap-3">
-                        <span class="icon-circle bg-success bg-opacity-25 text-success"><i class="bi bi-lightning-charge-fill"></i></span>
-                        <div>
-                            <h6 class="mb-0 text-white">Rapid Response</h6>
-                            <small class="text-white-50">Replies in under 24 hours</small>
-                        </div>
+                <div class="d-flex flex-column flex-sm-row gap-3">
+                    <a href="/packages" class="btn btn-gradient btn-lg shadow-lg">Browse rental packages</a>
+                    <a href="/about/contact/#contactForm" class="btn btn-outline-light btn-lg">Plan your event</a>
+                </div>
+                <div class="d-flex flex-wrap gap-4 mt-5 hero-stats">
+                    <div class="stat">
+                        <span class="stat-value">24 hr</span>
+                        <span class="stat-label">Average response time</span>
                     </div>
-                    <div class="d-flex align-items-center gap-3">
-                        <span class="icon-circle bg-success bg-opacity-25 text-success"><i class="bi bi-people-fill"></i></span>
-                        <div>
-                            <h6 class="mb-0 text-white">Expert Guidance</h6>
-                            <small class="text-white-50">Seasoned engineers on staff</small>
-                        </div>
+                    <div class="stat">
+                        <span class="stat-value">100%</span>
+                        <span class="stat-label">Custom recommendations</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-value">On-call</span>
+                        <span class="stat-label">Support every rental</span>
                     </div>
                 </div>
             </div>
-            <div class="col-lg-5">
+            <div class="col-lg-6">
                 <div class="contact-quick-links row g-3">
                     <div class="col-12">
                         <div class="card h-100 p-4">

--- a/faqs.html
+++ b/faqs.html
@@ -5,11 +5,12 @@ permalink: /about/faqs/
 ---
 
 
-<section class="faq-hero py-5 position-relative overflow-hidden">
-  <div class="container position-relative py-5">
+<section class="hero-section faq-hero text-white position-relative overflow-hidden">
+  <div class="hero-glow"></div>
+  <div class="container position-relative py-5 py-lg-6">
     <div class="row g-4 align-items-center mb-5">
       <div class="col-lg-8">
-        <span class="badge badge-soft-light d-inline-flex align-items-center gap-2 text-uppercase">
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase d-inline-flex align-items-center gap-2">
           <i class="bi bi-stars fs-5"></i>
           Support Center
         </span>

--- a/microphones.md
+++ b/microphones.md
@@ -9,7 +9,7 @@ permalink: /packages/audio/microphones/
   <div class="container py-5 py-lg-6">
     <div class="row align-items-center g-5">
       <div class="col-lg-7">
-        <span class="badge badge-soft-light text-uppercase">Microphone rentals</span>
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">Microphone rentals</span>
         <h1 class="display-4 fw-bold mt-4 text-white">Crystal-clear vocals, speeches, and recordings.</h1>
         <p class="lead text-white-50">From handheld wireless mics to studio staples, our curated kits include stands, cables, and expert setup so every word lands with impact.</p>
         <div class="d-flex flex-wrap gap-3 mt-4">

--- a/packages/index.html
+++ b/packages/index.html
@@ -9,7 +9,7 @@ permalink: /packages/
   <div class="container py-5 py-lg-6">
     <div class="row align-items-center g-5">
       <div class="col-lg-7">
-        <span class="badge badge-soft-light text-uppercase">Browse our rentals</span>
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">Browse our rentals</span>
         <h1 class="display-4 fw-bold mt-4 text-white">Curated packages for unforgettable events.</h1>
         <p class="lead text-white-50">High-impact audio and visual setups tailored for weddings, celebrations, markets, and corporate experiences. Choose a ready-to-go package or let us customize one for you.</p>
         <div class="d-flex flex-wrap gap-3 mt-4">


### PR DESCRIPTION
## Summary
- restyle the contact, FAQ, and brands page heroes to share the homepage layout, glow, and stat treatment
- add supporting styles for the brands hero media grid and reuse the hero eyebrow badge across package templates

## Testing
- not run (Bundler could not install gems in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d8de6ffecc832ca4ee29d6af737205