### PR TITLE
Add branding config variable and update site references

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ author: "Edwin Vans"
 email: "bookings@vproaudio.rentals"
 lang: "en"
 timezone: "America/Los_Angeles"
+branding: "V Pro Audio"
 
 year: 2025
 company: "VANS Professional Audio Rentals"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,9 +5,9 @@
       <div class="row gy-5">
         <div class="col-12 col-lg-4">
           <a href="/" class="footer-brand d-inline-flex align-items-center text-decoration-none text-light mb-4">
-            <img src="/assets/images/logo.svg" alt="{{ site.company }} Logo" width="64" height="64" class="flex-shrink-0">
+            <img src="/assets/images/logo.svg" alt="{{ site.branding }} Logo" width="64" height="64" class="flex-shrink-0">
             <div class="ms-3">
-              <span class="d-block fw-semibold fs-5">{{ site.company }}</span>
+              <span class="d-block fw-semibold fs-5">{{ site.branding }}</span>
               <span class="footer-tagline">{{ site.description }}</span>
             </div>
           </a>
@@ -66,7 +66,7 @@
   <div class="footer-bottom">
     <div class="container">
       <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center justify-content-between gap-2">
-        <small>&copy; {{ site.year }} {{ site.company }}. All Rights Reserved.</small>
+        <small>&copy; {{ 'now' | date: '%Y' }} {{ site.company }}. All Rights Reserved.</small>
         <small>All prices on this site are in USD.</small>
       </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
     <a class="navbar-brand d-flex align-items-center" href="/">
       <img src="/assets/images/logo.svg" alt="Logo" width="48" height="48" class="me-2">
       <span>
-        <span class="brand-title d-block">V Pro Audio</span>
+        <span class="brand-title d-block">{{ site.branding }}</span>
         <span class="brand-tagline d-none d-sm-block">Rentals &amp; Production</span>
       </span>
     </a>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ title: Home
 <section class="section-spacing">
   <div class="container">
     <div class="text-center mb-5">
-      <span class="badge badge-soft-primary">Why choose V Pro Audio</span>
+      <span class="badge badge-soft-primary">Why choose {{ site.branding }}</span>
       <h2 class="display-5 fw-bold mt-3">Boutique rentals. Concert-level sound.</h2>
       <p class="lead text-muted">We obsess over the details so your event can sound effortless.</p>
     </div>

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -14,7 +14,7 @@ body_class: privacy-policy-page
         <h1 class="display-4 fw-bold mb-3">Your privacy, protected with intention.</h1>
         <p class="lead mb-4">
           We collect only what we need to support your event and safeguard it with industry-leading practices.
-          Review how your information is handled when you explore {{ site.company }} and our services.
+          Review how your information is handled when you explore {{ site.branding }} and our services.
         </p>
         <div class="d-inline-flex align-items-center gap-3 bg-white bg-opacity-10 rounded-4 px-4 py-3">
           <i class="bi bi-calendar-check fs-4 text-white"></i>


### PR DESCRIPTION
## Summary
- add a reusable `branding` config value for the public-facing name
- replace hard-coded branding text in the header, home page badge, and privacy copy with the config variable
- keep the legal company name in the footer copyright while making the year dynamic

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8e9c53abc832c9b95930641958bf0