### PR TITLE
Remove privacy policy header background override

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -112,49 +112,6 @@ h1, h2, h3, h4, h5, h6 {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(20,26,54,0.85)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
-.privacy-policy-page {
-  .glassy-nav {
-    background: rgba(16, 21, 45, 0.85);
-    border-bottom-color: rgba(255, 255, 255, 0.15);
-  }
-
-  .navbar-brand {
-    color: #fff;
-
-    &:hover {
-      color: #fff;
-    }
-  }
-
-  .brand-title {
-    color: #fff;
-  }
-
-  .brand-tagline {
-    color: rgba(255, 255, 255, 0.75);
-  }
-
-  .navbar-nav .nav-link {
-    color: rgba(255, 255, 255, 0.85);
-
-    &:hover,
-    &:focus,
-    &.active {
-      color: #fff;
-      background-color: rgba(255, 255, 255, 0.12);
-      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
-    }
-  }
-
-  .navbar-toggler {
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-  }
-
-  .navbar-toggler-icon {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255,255,255,0.9)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  }
-}
-
 /* ============================================================
    Buttons & Badges
    ============================================================ */


### PR DESCRIPTION
## Summary
- remove the privacy-policy specific navigation overrides so the header keeps the default background

## Testing
- bundle exec jekyll build *(fails: jekyll executable unavailable because bundle install could not authenticate with rubygems)*

------
https://chatgpt.com/codex/tasks/task_e_68db6a8c2e10832cbae83e9b6fa86e6a