### PR TITLE
Fix footer CTA hover contrast

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -128,6 +128,19 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
+.btn-outline-light {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.75);
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: $primary;
+    background-color: #fff;
+    border-color: #fff;
+  }
+}
+
 .badge-soft-primary {
   background: rgba($primary, 0.1);
   color: $primary;


### PR DESCRIPTION
## Summary
- ensure the footer "Plan your event" call-to-action keeps a high contrast text color when hovered by overriding the `.btn-outline-light` styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db6b8588a8832c99e4e3e0fcb18818