### PR TITLE
Fix outline light button hover contrast

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -131,6 +131,14 @@ h1, h2, h3, h4, h5, h6 {
 .btn-outline-light {
   color: #fff;
   border-color: rgba(255, 255, 255, 0.75);
+  --bs-btn-color: #fff;
+  --bs-btn-border-color: rgba(255, 255, 255, 0.75);
+  --bs-btn-hover-color: $primary;
+  --bs-btn-hover-bg: #fff;
+  --bs-btn-hover-border-color: #fff;
+  --bs-btn-active-color: $primary;
+  --bs-btn-active-bg: #fff;
+  --bs-btn-active-border-color: #fff;
 
   &:hover,
   &:focus,


### PR DESCRIPTION
## Summary
- update the outline light button styles to define Bootstrap CSS variables for hover and active states
- ensure the "Plan your event" button text switches to a dark color against its white hover background for better readability

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68db6d9fce50832ca0d1419971fd3aac