### PR TITLE
Fix outline light button hover contrast

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -129,13 +129,21 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-outline-light {
-  color: #fff;
+  color: rgba(255, 255, 255, 0.92);
   border-color: rgba(255, 255, 255, 0.75);
+  --bs-btn-color: rgba(255, 255, 255, 0.92);
+  --bs-btn-border-color: rgba(255, 255, 255, 0.75);
+  --bs-btn-hover-color: $primary;
+  --bs-btn-hover-bg: #fff;
+  --bs-btn-hover-border-color: #fff;
+  --bs-btn-active-color: $primary;
+  --bs-btn-active-bg: #fff;
+  --bs-btn-active-border-color: #fff;
 
   &:hover,
   &:focus,
   &:active {
-    color: $primary;
+    color: $primary !important;
     background-color: #fff;
     border-color: #fff;
   }


### PR DESCRIPTION
## Summary
- update the outline light button styles to keep the Bootstrap hover and active variables pointing at the primary text color
- force the "Plan your event" button text to use the dark primary color on hover and active so it stays readable against the white background

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68db6d9fce50832ca0d1419971fd3aac