### PR TITLE
Restyle hero gradient with original palette

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -171,26 +171,26 @@ h1, h2, h3, h4, h5, h6 {
    Hero Section
    ============================================================ */
 .hero-section {
-  background: linear-gradient(135deg, #10152d 0%, #19203a 55%, #262a46 100%);
+  background: conic-gradient(from 160deg at 22% 24%, #10152d 0deg, #19203a 150deg, #262a46 320deg, #10152d 360deg);
   position: relative;
 }
 
 .hero-section::before {
   content: "";
   position: absolute;
-  inset: -10rem -20rem auto;
-  height: 380px;
-  background: radial-gradient(circle at top left, rgba($success, 0.45), transparent 60%);
-  opacity: 0.7;
+  inset: -8rem -22rem auto;
+  height: 420px;
+  background: radial-gradient(circle at top left, rgba($success, 0.45) 0%, rgba($success, 0) 68%);
+  opacity: 0.75;
   z-index: 0;
 }
 
 .hero-glow {
   position: absolute;
-  inset: auto -30% -40% auto;
-  width: 420px;
-  height: 420px;
-  background: radial-gradient(circle, rgba(111, 123, 255, 0.55), transparent 70%);
+  inset: auto -22% -46% auto;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle at center, rgba(111, 123, 255, 0.48) 0%, rgba(255, 183, 77, 0.22) 52%, rgba(16, 21, 45, 0) 85%);
   filter: blur(0);
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- restyle the shared hero background with a conic gradient that keeps the original deep blue palette without layered overlays
- retune the hero accent and glow treatments to match the restored color scheme

## Testing
- not run (bundle install fails: Gem::Net::HTTPClientException 403 "Forbidden")

------
https://chatgpt.com/codex/tasks/task_e_68db6d582434832c83812c1ad8b64259