### PR TITLE
Make trusted equipment brands section horizontally scrollable

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -304,6 +304,36 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
 }
 
+.brand-logos-scroll {
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  overflow-x: auto;
+  padding: 0.5rem 1rem;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+
+  &::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba($primary, 0.2);
+    border-radius: 999px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba($primary, 0.05);
+    border-radius: 999px;
+  }
+
+  .brand-logo-item {
+    flex: 0 0 auto;
+    scroll-snap-align: center;
+    min-width: 120px;
+  }
+}
+
 .brand-logos img {
   filter: grayscale(100%);
   opacity: 0.65;

--- a/index.html
+++ b/index.html
@@ -53,18 +53,18 @@ title: Home
 <!-- EQUIPMENT BRANDS SECTION -->
 <section class="section-spacing trusted-by text-center">
   <div class="container">
-    <p class="eyebrow-text text-muted text-uppercase mb-4">Equipment we trust and rely on</p>
-    <div class="row justify-content-center align-items-center g-4 brand-logos">
-      <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+    <p class="eyebrow-text text-muted text-uppercase mb-4">Elite brands powering every performance</p>
+    <div class="brand-logos brand-logos-scroll">
+      <div class="brand-logo-item">
         <img src="/assets/images/shure.png" class="img-fluid" alt="Shure">
       </div>
-      <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+      <div class="brand-logo-item">
         <img src="/assets/images/mackie.png" class="img-fluid" alt="Mackie">
       </div>
-      <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+      <div class="brand-logo-item">
         <img src="/assets/images/yamaha.png" class="img-fluid" alt="Yamaha">
       </div>
-      <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+      <div class="brand-logo-item">
         <img src="/assets/images/ev.png" class="img-fluid" alt="Electro-Voice">
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the trusted equipment brands headline to reinforce performance impact
- convert the brand logo grid into a horizontally scrollable strip with snap alignment
- style the scrolling container and scrollbar for a smoother browsing experience

## Testing
- ⚠️ `bundle install` *(fails: Rubygems 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e093289fd8832c89ffc76ac897c504