### PR TITLE
Remove power output section from package pages

### DIFF
--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -102,16 +102,6 @@
 
               <ul class="package-stats list-unstyled d-flex flex-wrap gap-4 mt-4 mb-0">
                 <li class="stat-item">
-                  <span class="stat-label">Power Output</span>
-                  <span class="stat-value">
-                    {% if page.system_power %}
-                      {{ page.system_power }}W
-                    {% else %}
-                      Custom-tuned
-                    {% endif %}
-                  </span>
-                </li>
-                <li class="stat-item">
                   <span class="stat-label">Service Area</span>
                   <span class="stat-value">Vacaville, California</span>
                 </li>


### PR DESCRIPTION
## Summary
- remove the power output stat from the package layout hero so it no longer renders on package pages

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e095e97474832ca115dd3be595993b