### PR TITLE
Update site call-to-action links to use new phone number

### DIFF
--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -95,7 +95,7 @@
                   <span class="price-period">per day</span>
                 </div>
                 <a href="/about/contact/" class="btn btn-gradient btn-lg shadow-lg">Reserve this package</a>
-                <a href="tel:+17072268726" class="btn btn-outline-light btn-lg">
+                <a href="tel:+17076600414" class="btn btn-outline-light btn-lg">
                   <i class="bi bi-telephone me-2"></i>Call us
                 </a>
               </div>

--- a/contact.html
+++ b/contact.html
@@ -230,7 +230,10 @@ permalink: /about/contact/
                         <span class="icon-circle text-success"><i class="bi bi-headset"></i></span>
                         <div>
                             <h4 class="mb-1">Need immediate assistance?</h4>
-                            <p class="mb-0 text-muted">Call our on-call engineer line at <strong>(707) 999-1318</strong>.</p>
+                            <p class="mb-0 text-muted">
+                                Call our on-call engineer line at
+                                <a href="tel:+17076600414" class="fw-semibold text-success text-decoration-none">Call now</a>.
+                            </p>
                         </div>
                     </div>
                     <ul class="list-unstyled mb-4 text-muted">

--- a/microphones.md
+++ b/microphones.md
@@ -92,7 +92,7 @@ permalink: /packages/audio/microphones/
       </div>
       <div class="d-flex flex-column flex-sm-row gap-3">
         <a href="/about/contact/" class="btn btn-gradient btn-lg">Request availability</a>
-        <a href="tel:+17072268726" class="btn btn-outline-primary btn-lg">Talk with an audio tech</a>
+        <a href="tel:+17076600414" class="btn btn-outline-primary btn-lg">Talk with an audio tech</a>
       </div>
     </div>
   </div>

--- a/packages/index.html
+++ b/packages/index.html
@@ -14,7 +14,7 @@ permalink: /packages/
         <p class="lead text-white-50">High-impact audio and visual setups tailored for weddings, celebrations, markets, and corporate experiences. Choose a ready-to-go package or let us customize one for you.</p>
         <div class="d-flex flex-wrap gap-3 mt-4">
           <a href="/about/contact/" class="btn btn-gradient btn-lg shadow-lg">Talk to a specialist</a>
-          <a href="tel:+17072268726" class="btn btn-outline-light btn-lg">Call (707) 226-8726</a>
+          <a href="tel:+17076600414" class="btn btn-outline-light btn-lg">Call now</a>
         </div>
       </div>
       <div class="col-lg-5">


### PR DESCRIPTION
## Summary
- update CTA phone links across packages and microphone pages to dial the new on-call number
- adjust contact page messaging to keep the phone number hidden while still providing a call link
- ensure layout call button routes to the updated number without exposing digits in the UI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0974f0c10832c92d2a6b1892717f0