### PR TITLE
Redesign brands showcase cards and update response time copy

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -285,6 +285,105 @@ h1, h2, h3, h4, h5, h6 {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
+.brand-showcase {
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 40px 10% -20%;
+    background: radial-gradient(circle at top, rgba($primary, 0.08) 0%, rgba($primary, 0) 70%);
+    pointer-events: none;
+    z-index: -1;
+  }
+}
+
+.brand-card {
+  background: #fff;
+  border: 1px solid rgba($primary, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: 0 22px 48px rgba(20, 26, 54, 0.08);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  overflow: hidden;
+  display: flex;
+  align-items: stretch;
+  isolate: isolate;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(140deg, rgba($primary, 0.08) 0%, rgba($success, 0.18) 50%, rgba($primary, 0.1) 100%);
+    opacity: 0;
+    transition: opacity 0.35s ease;
+  }
+
+  &:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 32px 68px rgba(20, 26, 54, 0.16);
+
+    &::before {
+      opacity: 1;
+    }
+  }
+}
+
+.brand-card-body {
+  position: relative;
+  z-index: 1;
+  padding: 2.25rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.25rem;
+}
+
+.brand-logo-wrapper {
+  width: 116px;
+  height: 116px;
+  border-radius: 36px;
+  background: linear-gradient(145deg, rgba($primary, 0.05) 0%, rgba($primary, 0.12) 100%);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 1px rgba($primary, 0.08), 0 22px 36px rgba(20, 26, 54, 0.14);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.brand-card:hover .brand-logo-wrapper {
+  transform: scale(1.05) translateY(-4px);
+  box-shadow: inset 0 0 0 1px rgba($primary, 0.12), 0 26px 44px rgba(20, 26, 54, 0.18);
+}
+
+.brand-logo {
+  max-width: 80%;
+  max-height: 64px;
+  filter: grayscale(100%);
+  opacity: 0.8;
+  transition: transform 0.35s ease, filter 0.35s ease, opacity 0.35s ease;
+}
+
+.brand-card:hover .brand-logo {
+  filter: none;
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.brand-name {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.brand-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba($secondary, 0.78);
+}
+
 /* ============================================================
    Sections
    ============================================================ */

--- a/brands.html
+++ b/brands.html
@@ -52,35 +52,57 @@ permalink: /about/brands/
 </section>
 
 <!-- Brands Grid -->
-<div class="container pb-5">
-  <div class="row row-cols-2 row-cols-md-4 g-4 justify-content-center">
-    <div class="col">
-      <div class="card border-0 shadow-sm p-3 h-100 text-center brand-card fade-in">
-        <a href="https://www.electrovoice.com/" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Electro-Voice: High-quality microphones and speakers.">
-          <img src="/assets/images/ev.png" alt="Electro-Voice" class="img-fluid mx-auto brand-logo">
-        </a>
+<section class="brand-showcase py-5">
+  <div class="container">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4 brand-card-grid">
+      <div class="col">
+        <article class="brand-card h-100 position-relative">
+          <div class="brand-card-body">
+            <div class="brand-logo-wrapper">
+              <img src="/assets/images/ev.png" alt="Electro-Voice" class="brand-logo">
+            </div>
+            <h3 class="brand-name">Electro-Voice</h3>
+            <p class="brand-description">High-quality microphones and speakers trusted for touring rigs.</p>
+          </div>
+          <a href="https://www.electrovoice.com/" class="stretched-link" target="_blank" rel="noopener"></a>
+        </article>
       </div>
-    </div>
-    <div class="col">
-      <div class="card border-0 shadow-sm p-3 h-100 text-center brand-card fade-in">
-        <a href="https://mackie.com/" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Mackie: Professional audio mixers and loudspeakers.">
-          <img src="/assets/images/mackie.png" alt="Mackie" class="img-fluid mx-auto brand-logo">
-        </a>
+      <div class="col">
+        <article class="brand-card h-100 position-relative">
+          <div class="brand-card-body">
+            <div class="brand-logo-wrapper">
+              <img src="/assets/images/mackie.png" alt="Mackie" class="brand-logo">
+            </div>
+            <h3 class="brand-name">Mackie</h3>
+            <p class="brand-description">Professional mixers and loudspeakers for reliable live sound.</p>
+          </div>
+          <a href="https://mackie.com/" class="stretched-link" target="_blank" rel="noopener"></a>
+        </article>
       </div>
-    </div>
-    <div class="col">
-      <div class="card border-0 shadow-sm p-3 h-100 text-center brand-card fade-in">
-        <a href="https://www.shure.com/" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Shure: Legendary microphones and audio electronics.">
-          <img src="/assets/images/shure.png" alt="Shure" class="img-fluid mx-auto brand-logo">
-        </a>
+      <div class="col">
+        <article class="brand-card h-100 position-relative">
+          <div class="brand-card-body">
+            <div class="brand-logo-wrapper">
+              <img src="/assets/images/shure.png" alt="Shure" class="brand-logo">
+            </div>
+            <h3 class="brand-name">Shure</h3>
+            <p class="brand-description">Legendary microphones and wireless systems for every stage.</p>
+          </div>
+          <a href="https://www.shure.com/" class="stretched-link" target="_blank" rel="noopener"></a>
+        </article>
       </div>
-    </div>
-    <div class="col">
-      <div class="card border-0 shadow-sm p-3 h-100 text-center brand-card fade-in">
-        <a href="https://usa.yamaha.com/" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Yamaha: Renowned musical instruments and professional audio.">
-          <img src="/assets/images/yamaha.png" alt="Yamaha" class="img-fluid mx-auto brand-logo">
-        </a>
+      <div class="col">
+        <article class="brand-card h-100 position-relative">
+          <div class="brand-card-body">
+            <div class="brand-logo-wrapper">
+              <img src="/assets/images/yamaha.png" alt="Yamaha" class="brand-logo">
+            </div>
+            <h3 class="brand-name">Yamaha</h3>
+            <p class="brand-description">Renowned instruments and pro audio gear for any venue.</p>
+          </div>
+          <a href="https://usa.yamaha.com/" class="stretched-link" target="_blank" rel="noopener"></a>
+        </article>
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/contact.html
+++ b/contact.html
@@ -105,7 +105,7 @@ permalink: /about/contact/
                 </div>
                 <div class="d-flex flex-wrap gap-4 mt-5 hero-stats">
                     <div class="stat">
-                        <span class="stat-value">24 hr</span>
+                        <span class="stat-value">&lt; 1 hr</span>
                         <span class="stat-label">Average response time</span>
                     </div>
                     <div class="stat">

--- a/faqs.html
+++ b/faqs.html
@@ -21,7 +21,7 @@ permalink: /about/faqs/
         <div class="d-flex flex-wrap gap-3 mt-4">
           <div class="faq-highlight-pill">
             <i class="bi bi-clock-history"></i>
-            <span>Average response time <strong>under 24 hours</strong></span>
+            <span>Average response time <strong>under 1 hour</strong></span>
           </div>
           <div class="faq-highlight-pill">
             <i class="bi bi-shield-check"></i>


### PR DESCRIPTION
## Summary
- redesign the brands grid into responsive feature cards with hover animation and descriptions
- add supporting SCSS to style the brand showcase section
- update FAQ and contact hero copy to state the new under 1 hour response time

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e09b9ff62c832cb90b531a4c6163f4