### PR TITLE
Improve brand card link accessibility

### DIFF
--- a/brands.html
+++ b/brands.html
@@ -61,10 +61,11 @@ permalink: /about/brands/
             <div class="brand-logo-wrapper">
               <img src="/assets/images/ev.png" alt="Electro-Voice" class="brand-logo">
             </div>
-            <h3 class="brand-name">Electro-Voice</h3>
+            <h3 class="brand-name">
+              <a href="https://www.electrovoice.com/" class="stretched-link text-decoration-none" target="_blank" rel="noopener noreferrer">Electro-Voice</a>
+            </h3>
             <p class="brand-description">High-quality microphones and speakers trusted for touring rigs.</p>
           </div>
-          <a href="https://www.electrovoice.com/" class="stretched-link" target="_blank" rel="noopener"></a>
         </article>
       </div>
       <div class="col">
@@ -73,10 +74,11 @@ permalink: /about/brands/
             <div class="brand-logo-wrapper">
               <img src="/assets/images/mackie.png" alt="Mackie" class="brand-logo">
             </div>
-            <h3 class="brand-name">Mackie</h3>
+            <h3 class="brand-name">
+              <a href="https://mackie.com/" class="stretched-link text-decoration-none" target="_blank" rel="noopener noreferrer">Mackie</a>
+            </h3>
             <p class="brand-description">Professional mixers and loudspeakers for reliable live sound.</p>
           </div>
-          <a href="https://mackie.com/" class="stretched-link" target="_blank" rel="noopener"></a>
         </article>
       </div>
       <div class="col">
@@ -85,10 +87,11 @@ permalink: /about/brands/
             <div class="brand-logo-wrapper">
               <img src="/assets/images/shure.png" alt="Shure" class="brand-logo">
             </div>
-            <h3 class="brand-name">Shure</h3>
+            <h3 class="brand-name">
+              <a href="https://www.shure.com/" class="stretched-link text-decoration-none" target="_blank" rel="noopener noreferrer">Shure</a>
+            </h3>
             <p class="brand-description">Legendary microphones and wireless systems for every stage.</p>
           </div>
-          <a href="https://www.shure.com/" class="stretched-link" target="_blank" rel="noopener"></a>
         </article>
       </div>
       <div class="col">
@@ -97,10 +100,11 @@ permalink: /about/brands/
             <div class="brand-logo-wrapper">
               <img src="/assets/images/yamaha.png" alt="Yamaha" class="brand-logo">
             </div>
-            <h3 class="brand-name">Yamaha</h3>
+            <h3 class="brand-name">
+              <a href="https://usa.yamaha.com/" class="stretched-link text-decoration-none" target="_blank" rel="noopener noreferrer">Yamaha</a>
+            </h3>
             <p class="brand-description">Renowned instruments and pro audio gear for any venue.</p>
           </div>
-          <a href="https://usa.yamaha.com/" class="stretched-link" target="_blank" rel="noopener"></a>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap each brand card heading in the stretched link so the external destination has an accessible name
- keep the card appearance by reusing the stretched-link utility with text-decoration suppression while allowing focus outlines

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e09dab5eac832c8e95c77e821bd4e3