### PR TITLE
Increase brand card logo sizing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -341,9 +341,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .brand-logo-wrapper {
-  width: 116px;
-  height: 116px;
-  border-radius: 36px;
+  width: 140px;
+  height: 140px;
+  border-radius: 44px;
   background: linear-gradient(145deg, rgba($primary, 0.05) 0%, rgba($primary, 0.12) 100%);
   display: grid;
   place-items: center;
@@ -357,8 +357,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .brand-logo {
-  max-width: 80%;
-  max-height: 64px;
+  max-width: 90%;
+  max-height: 80px;
   filter: grayscale(100%);
   opacity: 0.8;
   transition: transform 0.35s ease, filter 0.35s ease, opacity 0.35s ease;


### PR DESCRIPTION
## Summary
- enlarge the brand card logo container for more prominent imagery
- raise the maximum dimensions of brand logos so the artwork displays larger

## Testing
- not run (bundle install blocked by rubygems 403 response)

------
https://chatgpt.com/codex/tasks/task_e_68e09ed57260832c8c8afa1c143b5db3