### PR TITLE
Increase equipment brand logo size

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -341,9 +341,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .brand-logo-wrapper {
-  width: 140px;
-  height: 140px;
-  border-radius: 44px;
+  width: 160px;
+  height: 160px;
+  border-radius: 52px;
   background: linear-gradient(145deg, rgba($primary, 0.05) 0%, rgba($primary, 0.12) 100%);
   display: grid;
   place-items: center;
@@ -357,8 +357,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .brand-logo {
-  max-width: 90%;
-  max-height: 80px;
+  max-width: 92%;
+  max-height: 100px;
   filter: grayscale(100%);
   opacity: 0.8;
   transition: transform 0.35s ease, filter 0.35s ease, opacity 0.35s ease;


### PR DESCRIPTION
## Summary
- enlarge the brand card logo wrapper to provide larger images
- increase the logo max dimensions for improved visibility on the equipment brands page

## Testing
- python3 -m http.server 4000

------
https://chatgpt.com/codex/tasks/task_e_68e09ff79524832cacb6546b8dc2fcd9