### PR TITLE
Add Support → Setup Instructions hub with categorized markdown-driven guides

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,9 @@ collections:
   packages:
     output: true
     permalink: /packages/:name/
+  setup_instructions:
+    output: true
+    permalink: /support/setup-instructions/:name/
 
 defaults:
   - scope:

--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -23,6 +23,10 @@
     - title: Karaoke & Party Pack
       url: /packages/party-audio/karaoke-and-party-pack/
 
+- title: Support
+  dropdown:
+    - title: Setup Instructions
+      url: /support/setup-instructions/
 
 - title: About
   dropdown:

--- a/_data/setup_instruction_categories.yml
+++ b/_data/setup_instruction_categories.yml
@@ -1,0 +1,14 @@
+- slug: audio-systems
+  title: Audio Systems
+  icon: "🎤"
+  description: Speaker, microphone, and mixer setup workflows for general events.
+
+- slug: karaoke-systems
+  title: Karaoke Systems
+  icon: "🎤"
+  description: Plug-and-play karaoke configuration and audio balancing guides.
+
+- slug: projector-systems
+  title: Projector Systems
+  icon: "📽️"
+  description: Display and projection setup instructions for presentations and events.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,7 +26,7 @@
           {% if item.dropdown %}
             {% assign active = false %}
             {% for sub in item.dropdown %}
-              {% if page.url == sub.url %}
+              {% if page.url == sub.url or (sub.url != "/" and page.url contains sub.url) %}
                 {% assign active = true %}
               {% endif %}
             {% endfor %}
@@ -46,7 +46,7 @@
                     <li><hr class="dropdown-divider"></li>
                   {% else %}
                     <li>
-                      <a class="dropdown-item {% if page.url == sub.url %}active{% endif %}" href="{{ sub.url }}">
+                      <a class="dropdown-item {% if page.url == sub.url or (sub.url != "/" and page.url contains sub.url) %}active{% endif %}" href="{{ sub.url }}">
                         {{ sub.title }}
                       </a>
                     </li>

--- a/_setup_instructions/basic-speaker-setup.md
+++ b/_setup_instructions/basic-speaker-setup.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Basic Speaker Setup
+category: audio-systems
+order: 1
+summary: Place left/right speakers on stable stands and run power + signal before soundcheck.
+---
+
+## Overview
+Use this page for your full basic speaker setup instructions.
+
+## Recommended checklist
+- Add equipment list details.
+- Add cable routing and power-on sequence.
+- Add testing checklist and troubleshooting notes.
+
+## Notes
+Replace this placeholder content with your final setup guide.

--- a/_setup_instructions/karaoke-setup-guide.md
+++ b/_setup_instructions/karaoke-setup-guide.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Karaoke Setup Guide
+category: karaoke-systems
+order: 1
+summary: Connect karaoke source outputs into the mixer and balance vocals with backing tracks.
+---
+
+## Overview
+Use this page for your full karaoke setup guide instructions.
+
+## Recommended checklist
+- Add equipment list details.
+- Add cable routing and power-on sequence.
+- Add testing checklist and troubleshooting notes.
+
+## Notes
+Replace this placeholder content with your final setup guide.

--- a/_setup_instructions/mixer-bluetooth-setup.md
+++ b/_setup_instructions/mixer-bluetooth-setup.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Mixer + Bluetooth Setup
+category: audio-systems
+order: 3
+summary: Route Bluetooth audio to a stereo mixer channel and set gain before raising mains.
+---
+
+## Overview
+Use this page for your full mixer + bluetooth setup instructions.
+
+## Recommended checklist
+- Add equipment list details.
+- Add cable routing and power-on sequence.
+- Add testing checklist and troubleshooting notes.
+
+## Notes
+Replace this placeholder content with your final setup guide.

--- a/_setup_instructions/projector-screen-setup.md
+++ b/_setup_instructions/projector-screen-setup.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Projector + Screen Setup
+category: projector-systems
+order: 1
+summary: Align the projector with the screen center and confirm HDMI source resolution settings.
+---
+
+## Overview
+Use this page for your full projector + screen setup instructions.
+
+## Recommended checklist
+- Add equipment list details.
+- Add cable routing and power-on sequence.
+- Add testing checklist and troubleshooting notes.
+
+## Notes
+Replace this placeholder content with your final setup guide.

--- a/_setup_instructions/wireless-microphone-setup.md
+++ b/_setup_instructions/wireless-microphone-setup.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Wireless Microphone Setup
+category: audio-systems
+order: 2
+summary: Pair the receiver and transmitter channels, then verify clean gain staging.
+---
+
+## Overview
+Use this page for your full wireless microphone setup instructions.
+
+## Recommended checklist
+- Add equipment list details.
+- Add cable routing and power-on sequence.
+- Add testing checklist and troubleshooting notes.
+
+## Notes
+Replace this placeholder content with your final setup guide.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1280,3 +1280,84 @@ body {
 .policy-hero-card .text-white-50 {
   color: rgba(255, 255, 255, 0.65) !important;
 }
+
+
+/* ============================================================
+   Setup Instructions
+   ============================================================ */
+.setup-hero-card {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  backdrop-filter: blur(6px);
+}
+
+.setup-content {
+  position: relative;
+}
+
+.setup-sidebar {
+  top: 108px;
+  border-radius: 1rem;
+}
+
+.setup-sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.8rem;
+  color: $primary;
+  font-weight: 600;
+  background: rgba($primary, 0.03);
+  transition: all 0.2s ease;
+}
+
+.setup-sidebar-link:hover,
+.setup-sidebar-link:focus {
+  background: rgba($primary, 0.1);
+  transform: translateX(4px);
+}
+
+.setup-sidebar-icon {
+  font-size: 1.1rem;
+}
+
+.setup-count {
+  margin-left: auto;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: rgba($primary, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+}
+
+.setup-section {
+  border-radius: 1.25rem;
+}
+
+.setup-guide-card {
+  position: relative;
+  border-radius: 1rem;
+  border: 1px solid rgba($primary, 0.08);
+  background: linear-gradient(160deg, #fff 0%, #f9faff 100%);
+  box-shadow: 0 14px 32px rgba($primary, 0.06);
+  padding: 1.25rem;
+  height: 100%;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.setup-guide-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 34px rgba($primary, 0.1);
+}
+
+@media (max-width: 991.98px) {
+  .setup-sidebar {
+    position: static !important;
+  }
+}

--- a/setup-instructions.html
+++ b/setup-instructions.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Support - Setup Instructions
+permalink: /support/setup-instructions/
+---
+
+<section class="hero-section setup-hero text-white position-relative overflow-hidden">
+  <div class="hero-glow"></div>
+  <div class="container py-5 py-lg-6">
+    <div class="row g-4 align-items-end">
+      <div class="col-lg-8">
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase d-inline-flex align-items-center gap-2">
+          <i class="bi bi-tools"></i>
+          Support Library
+        </span>
+        <h1 class="display-4 fw-bold text-white mt-3 mb-3">Setup Instructions</h1>
+        <p class="lead text-white-50 mb-0">Browse step-by-step setup guides by system type. Add new markdown instructions to the setup library and they’ll appear here automatically.</p>
+      </div>
+      <div class="col-lg-4">
+        <div class="setup-hero-card">
+          <h2 class="h5 text-white mb-2">How to add new guides</h2>
+          <p class="small text-white-50 mb-0">Create a markdown file in <code>_setup_instructions/</code>, assign a category, and publish. This page groups and displays it automatically.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="setup-content py-5">
+  <div class="container">
+    <div class="row g-4 g-lg-5 align-items-start">
+      <aside class="col-lg-4 col-xl-3">
+        <nav class="setup-sidebar card border-0 shadow-sm sticky-lg-top" aria-label="Setup instruction categories">
+          <div class="card-body p-3 p-lg-4">
+            <p class="text-uppercase small fw-semibold text-muted mb-3">Categories</p>
+            <ul class="list-unstyled d-grid gap-2 mb-0">
+              {% for category in site.data.setup_instruction_categories %}
+                {% assign category_items = site.setup_instructions | where: "category", category.slug | sort: "order" %}
+                {% if category_items.size > 0 %}
+                  <li>
+                    <a class="setup-sidebar-link" href="#{{ category.slug }}">
+                      <span class="setup-sidebar-icon">{{ category.icon }}</span>
+                      <span>{{ category.title }}</span>
+                      <span class="setup-count">{{ category_items.size }}</span>
+                    </a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </div>
+        </nav>
+      </aside>
+
+      <div class="col-lg-8 col-xl-9">
+        <div class="d-grid gap-4">
+          {% for category in site.data.setup_instruction_categories %}
+            {% assign category_items = site.setup_instructions | where: "category", category.slug | sort: "order" %}
+            {% if category_items.size > 0 %}
+              <section id="{{ category.slug }}" class="setup-section card border-0 shadow-sm">
+                <div class="card-body p-4 p-lg-5">
+                  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                    <h2 class="h3 mb-0 d-flex align-items-center gap-2">
+                      <span>{{ category.icon }}</span>
+                      {{ category.title }}
+                    </h2>
+                    <span class="badge badge-soft-primary">{{ category_items.size }} Guide{% if category_items.size > 1 %}s{% endif %}</span>
+                  </div>
+                  {% if category.description %}
+                    <p class="text-muted mb-4">{{ category.description }}</p>
+                  {% endif %}
+
+                  <div class="row row-cols-1 row-cols-md-2 g-3 g-lg-4">
+                    {% for instruction in category_items %}
+                      <div class="col">
+                        <article class="setup-guide-card h-100">
+                          <h3 class="h5 mb-2">
+                            <a class="stretched-link text-decoration-none" href="{{ instruction.url }}">{{ instruction.title }}</a>
+                          </h3>
+                          {% if instruction.summary %}
+                            <p class="text-muted mb-0">{{ instruction.summary }}</p>
+                          {% else %}
+                            <p class="text-muted mb-0">Open this guide for complete setup details and step-by-step directions.</p>
+                          {% endif %}
+                        </article>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </section>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a centralized, markdown-driven Support > Setup Instructions hub so setup guides can be authored as simple pages and automatically surfaced by category.
- Keep the new support content visually consistent with the existing site and make it easy to add or reorder guides without code changes.

### Description
- Added a `Support` dropdown to the main navigation in `_data/menu.yml` and updated `_includes/header.html` dropdown active-state logic so parent items stay highlighted for nested pages.
- Introduced a new Jekyll collection `setup_instructions` in `_config.yml` and a category data file at `_data/setup_instruction_categories.yml` to control category labels, icons, and descriptions.
- Added a hub page `setup-instructions.html` that renders a sticky side category menu and grouped instruction cards by filtering `site.setup_instructions` by `category` and `order`.
- Created starter guide markdown files in `_setup_instructions/` (each with `title`, `category`, `order`, `summary`) and appended styles to `assets/css/main.scss` so the page matches the site’s visual language.

### Testing
- Attempted to validate site generation with `bundle exec jekyll build`, which failed in this environment because the `jekyll` executable is not available (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05c8f55f8832c831e22e17a1c7ca1)