### PR TITLE
Redesign setup instructions page with accordion navigation and single content card

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1336,6 +1336,83 @@ body {
   font-size: 0.75rem;
 }
 
+.setup-sidebar-accordion {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.setup-sidebar-group {
+  background: transparent;
+}
+
+.setup-category-toggle,
+.setup-category-toggle:not(.collapsed) {
+  border-radius: 0.85rem !important;
+  padding: 0.65rem 0.8rem;
+  color: $primary;
+  font-weight: 600;
+  background: rgba($primary, 0.03);
+  box-shadow: none;
+}
+
+.setup-category-toggle:hover,
+.setup-category-toggle:focus {
+  background: rgba($primary, 0.1);
+}
+
+.setup-category-toggle::after {
+  margin-left: 0.6rem;
+}
+
+.setup-guide-link {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba($primary, 0.1);
+  border-radius: 0.75rem;
+  background: #fff;
+  color: $primary;
+  font-weight: 500;
+  padding: 0.6rem 0.75rem;
+  transition: all 0.2s ease;
+}
+
+.setup-guide-link:hover,
+.setup-guide-link:focus {
+  border-color: rgba($primary, 0.25);
+  background: rgba($primary, 0.04);
+}
+
+.setup-guide-link.active {
+  border-color: rgba($primary, 0.45);
+  background: rgba($primary, 0.1);
+  box-shadow: 0 8px 20px rgba($primary, 0.08);
+}
+
+.setup-instruction-view {
+  border-radius: 1.25rem;
+}
+
+.setup-instruction-header {
+  border-bottom: 1px solid rgba($primary, 0.1);
+  padding-bottom: 1rem;
+}
+
+.setup-instruction-body {
+  color: $secondary;
+  line-height: 1.7;
+}
+
+.setup-instruction-body h2,
+.setup-instruction-body h3,
+.setup-instruction-body h4 {
+  margin-top: 1.2rem;
+}
+
+.setup-instruction-body ul,
+.setup-instruction-body ol {
+  padding-left: 1.2rem;
+}
+
 .setup-section {
   border-radius: 1.25rem;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,2 +1,48 @@
-// Custom JS can go here
-console.log("Bootstrap + Jekyll loaded!");
+// Setup instructions page interactions
+(() => {
+  const setupBody = document.getElementById("setupInstructionBody");
+  const setupTitle = document.getElementById("setupInstructionTitle");
+  const setupSummary = document.getElementById("setupInstructionSummary");
+  const guideButtons = document.querySelectorAll(".setup-guide-link[data-guide-key]");
+
+  if (!setupBody || !setupTitle || !setupSummary || guideButtons.length === 0) {
+    return;
+  }
+
+  const activateGuide = (guideKey) => {
+    const template = document.getElementById(`setup-guide-template-${guideKey}`);
+    if (!template) return;
+
+    const contentRoot = template.content.firstElementChild;
+    if (!contentRoot) return;
+
+    const guideTitle = contentRoot.dataset.guideTitle || "Setup Instructions";
+    const guideSummary =
+      contentRoot.dataset.guideSummary ||
+      "Select a setup link from the left menu to view the step-by-step instructions.";
+
+    setupTitle.textContent = guideTitle;
+    setupSummary.textContent = guideSummary;
+    setupBody.innerHTML = contentRoot.innerHTML;
+
+    guideButtons.forEach((button) => {
+      button.classList.toggle("active", button.dataset.guideKey === guideKey);
+    });
+
+    if (window.location.hash !== `#guide-${guideKey}`) {
+      window.history.replaceState(null, "", `#guide-${guideKey}`);
+    }
+  };
+
+  guideButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const { guideKey } = button.dataset;
+      activateGuide(guideKey);
+    });
+  });
+
+  const hashMatch = window.location.hash.match(/^#guide-(.+)$/);
+  if (hashMatch && hashMatch[1]) {
+    activateGuide(hashMatch[1]);
+  }
+})();

--- a/setup-instructions.html
+++ b/setup-instructions.html
@@ -4,6 +4,9 @@ title: Support - Setup Instructions
 permalink: /support/setup-instructions/
 ---
 
+{% assign all_setup_guides = site.setup_instructions | sort: "order" %}
+{% assign first_guide = all_setup_guides | first %}
+
 <section class="hero-section setup-hero text-white position-relative overflow-hidden">
   <div class="hero-glow"></div>
   <div class="container py-5 py-lg-6">
@@ -33,63 +36,88 @@ permalink: /support/setup-instructions/
         <nav class="setup-sidebar card border-0 shadow-sm sticky-lg-top" aria-label="Setup instruction categories">
           <div class="card-body p-3 p-lg-4">
             <p class="text-uppercase small fw-semibold text-muted mb-3">Categories</p>
-            <ul class="list-unstyled d-grid gap-2 mb-0">
+            <div class="accordion setup-sidebar-accordion" id="setupCategoryAccordion">
               {% for category in site.data.setup_instruction_categories %}
                 {% assign category_items = site.setup_instructions | where: "category", category.slug | sort: "order" %}
                 {% if category_items.size > 0 %}
-                  <li>
-                    <a class="setup-sidebar-link" href="#{{ category.slug }}">
-                      <span class="setup-sidebar-icon">{{ category.icon }}</span>
-                      <span>{{ category.title }}</span>
-                      <span class="setup-count">{{ category_items.size }}</span>
-                    </a>
-                  </li>
+                  <div class="accordion-item setup-sidebar-group border-0">
+                    <h2 class="accordion-header" id="heading-{{ category.slug }}">
+                      <button
+                        class="accordion-button setup-category-toggle {% unless forloop.first %}collapsed{% endunless %}"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-{{ category.slug }}"
+                        aria-expanded="{% if forloop.first %}true{% else %}false{% endif %}"
+                        aria-controls="collapse-{{ category.slug }}"
+                      >
+                        <span class="setup-sidebar-icon">{{ category.icon }}</span>
+                        <span>{{ category.title }}</span>
+                        <span class="setup-count">{{ category_items.size }}</span>
+                      </button>
+                    </h2>
+                    <div
+                      id="collapse-{{ category.slug }}"
+                      class="accordion-collapse collapse {% if forloop.first %}show{% endif %}"
+                      aria-labelledby="heading-{{ category.slug }}"
+                      data-bs-parent="#setupCategoryAccordion"
+                    >
+                      <div class="accordion-body px-0 pt-2 pb-0">
+                        <ul class="list-unstyled d-grid gap-2 mb-0">
+                          {% for instruction in category_items %}
+                            <li>
+                              <button
+                                type="button"
+                                class="setup-guide-link{% if first_guide and instruction.url == first_guide.url %} active{% endif %}"
+                                data-guide-key="{{ instruction.slug }}"
+                              >
+                                {{ instruction.title }}
+                              </button>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
                 {% endif %}
               {% endfor %}
-            </ul>
+            </div>
           </div>
         </nav>
       </aside>
 
       <div class="col-lg-8 col-xl-9">
-        <div class="d-grid gap-4">
-          {% for category in site.data.setup_instruction_categories %}
-            {% assign category_items = site.setup_instructions | where: "category", category.slug | sort: "order" %}
-            {% if category_items.size > 0 %}
-              <section id="{{ category.slug }}" class="setup-section card border-0 shadow-sm">
-                <div class="card-body p-4 p-lg-5">
-                  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
-                    <h2 class="h3 mb-0 d-flex align-items-center gap-2">
-                      <span>{{ category.icon }}</span>
-                      {{ category.title }}
-                    </h2>
-                    <span class="badge badge-soft-primary">{{ category_items.size }} Guide{% if category_items.size > 1 %}s{% endif %}</span>
-                  </div>
-                  {% if category.description %}
-                    <p class="text-muted mb-4">{{ category.description }}</p>
-                  {% endif %}
+        <section class="setup-instruction-view card border-0 shadow-sm">
+          {% if first_guide %}
+            <div class="card-body p-4 p-lg-5">
+              <header class="setup-instruction-header mb-4">
+                <p class="text-uppercase small fw-semibold text-muted mb-2">Setup Instructions</p>
+                <h2 id="setupInstructionTitle" class="h3 mb-2">{{ first_guide.title }}</h2>
+                {% if first_guide.summary %}
+                  <p id="setupInstructionSummary" class="text-muted mb-0">{{ first_guide.summary }}</p>
+                {% else %}
+                  <p id="setupInstructionSummary" class="text-muted mb-0">Select a setup link from the left menu to view the step-by-step instructions.</p>
+                {% endif %}
+              </header>
+              <article id="setupInstructionBody" class="setup-instruction-body">
+                {{ first_guide.content }}
+              </article>
+            </div>
 
-                  <div class="row row-cols-1 row-cols-md-2 g-3 g-lg-4">
-                    {% for instruction in category_items %}
-                      <div class="col">
-                        <article class="setup-guide-card h-100">
-                          <h3 class="h5 mb-2">
-                            <a class="stretched-link text-decoration-none" href="{{ instruction.url }}">{{ instruction.title }}</a>
-                          </h3>
-                          {% if instruction.summary %}
-                            <p class="text-muted mb-0">{{ instruction.summary }}</p>
-                          {% else %}
-                            <p class="text-muted mb-0">Open this guide for complete setup details and step-by-step directions.</p>
-                          {% endif %}
-                        </article>
-                      </div>
-                    {% endfor %}
+            <div class="d-none" id="setupGuideTemplates" aria-hidden="true">
+              {% for instruction in all_setup_guides %}
+                <template id="setup-guide-template-{{ instruction.slug }}">
+                  <div data-guide-title="{{ instruction.title | escape }}" data-guide-summary="{{ instruction.summary | escape }}">
+                    {{ instruction.content }}
                   </div>
-                </div>
-              </section>
-            {% endif %}
-          {% endfor %}
-        </div>
+                </template>
+              {% endfor %}
+            </div>
+          {% else %}
+            <div class="card-body p-4 p-lg-5">
+              <p class="mb-0 text-muted">No setup instructions are currently available. Add markdown files to <code>_setup_instructions/</code> to populate this page.</p>
+            </div>
+          {% endif %}
+        </section>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Preserve the existing Setup Instructions Hero while replacing the category-per-card layout with a single, updatable instruction card for selected guides.
- Expose category groups (Audio Systems, Karaoke Systems, Projector Systems) so their links are discoverable via expandable sections rather than separate Bootstrap cards.
- Provide an inline, client-driven content view so each guide's markdown can be displayed in-place without duplicating cards per category.

### Description
- Reworked the page template in `setup-instructions.html` to add an accordion-based sidebar, introduce `all_setup_guides` / `first_guide`, render a single `.setup-instruction-view` card, and include hidden per-guide `<template>` entries for content injection.
- Added client-side logic in `assets/js/main.js` to swap the single content card when a guide button is clicked, manage active states, and support hash deep-linking (`#guide-<slug>`).
- Added styling in `assets/css/main.scss` for the accordion groups, category toggle buttons, `.setup-guide-link` states, and the single instruction card presentation for a consistent visual layout.
- Kept the Setup Instructions Hero intact and ensured category groups expand to reveal links rather than rendering separate Bootstrap cards for Audio/Karaoke/Projector.

### Testing
- Attempted a site build with `bundle exec jekyll build`, but it failed in this environment because the `jekyll` executable is not available (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0684ce758832cbee5a790236d8262)