### PR TITLE
Add Setup Guides section with paginated blog, tags, and search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ source "https://rubygems.org"
 gem "jekyll"
 gem 'bootstrap', '~> 5.3.3'
 gem 'jekyll-seo-tag'
+
+gem 'jekyll-paginate-v2'

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ company: "VANS Professional Audio Rentals"
 
 plugins:
   - jekyll-seo-tag
+  - jekyll-paginate-v2
 
 seo:
   title: "VANS Pro Audio Rentals"
@@ -51,3 +52,11 @@ defaults:
       layout: "default"
       image: "/assets/images/home.jpg"
       author: "Edwin Vans"
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+
+# Blog pagination
+paginate_path: "/support/setup-guides/page/:num/"

--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -23,6 +23,10 @@
     - title: Karaoke & Party Pack
       url: /packages/party-audio/karaoke-and-party-pack/
 
+- title: Support
+  dropdown:
+    - title: Setup Guides
+      url: /support/setup-guides/
 
 - title: About
   dropdown:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+<article class="setup-post section-spacing py-5">
+  <div class="container" style="max-width: 900px;">
+    <header class="mb-4">
+      <a href="/support/setup-guides/" class="text-decoration-none small text-uppercase fw-semibold">
+        <i class="bi bi-arrow-left"></i> Back to Setup Guides
+      </a>
+      <h1 class="display-5 fw-bold mt-3">{{ page.title }}</h1>
+      <div class="text-muted d-flex flex-wrap gap-3 align-items-center">
+        <span><i class="bi bi-calendar3 me-1"></i>{{ page.date | date: "%B %d, %Y" }}</span>
+        {% if page.tags and page.tags.size > 0 %}
+          <span>
+            <i class="bi bi-tags me-1"></i>
+            {% for tag in page.tags %}
+              <span class="badge badge-soft-primary me-1">{{ tag }}</span>
+            {% endfor %}
+          </span>
+        {% endif %}
+      </div>
+    </header>
+
+    <div class="setup-post-content">
+      {{ content }}
+    </div>
+  </div>
+</article>

--- a/_posts/2026-04-17-basic-pa-setup-checklist.md
+++ b/_posts/2026-04-17-basic-pa-setup-checklist.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "Basic PA Setup Checklist for Small Events"
+date: 2026-04-17 09:00:00 -0700
+categories:
+  - setup-guides
+tags:
+  - speakers
+  - mixer
+  - microphones
+  - sound-check
+excerpt: "A practical checklist to set up your PA system quickly, avoid feedback, and run a clean sound check before guests arrive."
+---
+
+Hosting a small event and need clear, reliable audio? Use this quick setup sequence before attendees arrive.
+
+## 1) Place speakers first
+
+- Set left/right speakers slightly in front of microphones.
+- Aim speakers at audience ear level.
+- Keep speakers away from walls and corners when possible to reduce boominess.
+
+## 2) Connect mixer and sources
+
+1. Connect powered speakers to mixer main outputs.
+2. Connect wireless mic receiver (or wired mics) to individual channels.
+3. Connect music playback source (phone/laptop/playlist) to a stereo input.
+
+## 3) Set healthy gain structure
+
+- Keep channel faders near unity (0).
+- Raise each channel gain until signal peaks cleanly.
+- Avoid red clipping LEDs on channels and master output.
+
+## 4) Run a 60-second sound check
+
+- Speak into each microphone at event volume.
+- Play music at expected background level.
+- Walk the room and listen for dead spots or feedback.
+
+## 5) Lock in the event-ready mix
+
+- Reduce low frequencies slightly if vocals sound muddy.
+- Save your mixer scene (if supported).
+- Tape or secure loose cables in walkways.
+
+Need help selecting the right package? [Contact our team](/about/contact/) and we’ll help you spec your event setup.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1280,3 +1280,45 @@ body {
 .policy-hero-card .text-white-50 {
   color: rgba(255, 255, 255, 0.65) !important;
 }
+
+/* ============================================================
+   Setup Guides
+   ============================================================ */
+.page-link {
+  border: 1px solid rgba($primary, 0.12);
+  color: $primary;
+
+  &:hover {
+    color: $primary;
+    background: rgba($primary, 0.08);
+    border-color: rgba($primary, 0.2);
+  }
+}
+
+.page-item.active .page-link {
+  background: $primary;
+  border-color: $primary;
+}
+
+.setup-post-content {
+  font-size: 1.03rem;
+  line-height: 1.85;
+  color: lighten($secondary, 2%);
+
+  h2,
+  h3,
+  h4 {
+    margin-top: 2.2rem;
+    margin-bottom: 0.85rem;
+  }
+
+  ul,
+  ol {
+    padding-left: 1.25rem;
+  }
+
+  p,
+  li {
+    margin-bottom: 0.8rem;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,2 +1,28 @@
 // Custom JS can go here
 console.log("Bootstrap + Jekyll loaded!");
+
+document.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.getElementById('setupGuidesSearch');
+  const cards = Array.from(document.querySelectorAll('.guide-card-item'));
+  const noResults = document.getElementById('setupGuidesNoResults');
+
+  if (!searchInput || cards.length === 0 || !noResults) {
+    return;
+  }
+
+  const filterGuides = () => {
+    const query = searchInput.value.trim().toLowerCase();
+    let visibleCount = 0;
+
+    cards.forEach((card) => {
+      const haystack = card.dataset.search || '';
+      const isVisible = !query || haystack.includes(query);
+      card.classList.toggle('d-none', !isVisible);
+      if (isVisible) visibleCount += 1;
+    });
+
+    noResults.classList.toggle('d-none', visibleCount > 0);
+  };
+
+  searchInput.addEventListener('input', filterGuides);
+});

--- a/support/setup-guides/index.html
+++ b/support/setup-guides/index.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Setup Guides
+description: Step-by-step setup guides for V Pro Audio rentals.
+permalink: /support/setup-guides/
+pagination:
+  enabled: true
+  collection: posts
+  category: setup-guides
+  per_page: 6
+  permalink: /support/setup-guides/page/:num/
+---
+
+<section class="hero-section position-relative overflow-hidden text-white py-5">
+  <div class="hero-glow"></div>
+  <div class="container py-4">
+    <div class="row g-4 align-items-center">
+      <div class="col-lg-8">
+        <span class="badge rounded-pill text-bg-light hero-eyebrow text-uppercase">Support Resources</span>
+        <h1 class="display-5 fw-bold mt-3 text-white">Setup Guides</h1>
+        <p class="lead text-white-50 mb-0">Find quick walkthroughs for microphones, speakers, mixers, and event-ready sound checks.</p>
+      </div>
+      <div class="col-lg-4">
+        <div class="bg-white bg-opacity-10 rounded-4 p-3 p-md-4 shadow-sm">
+          <label for="setupGuidesSearch" class="form-label text-white fw-semibold">Search guides</label>
+          <div class="input-group">
+            <span class="input-group-text bg-white border-0"><i class="bi bi-search"></i></span>
+            <input id="setupGuidesSearch" class="form-control border-0" type="search" placeholder="Search by title, excerpt, or tag..." aria-label="Search setup guides">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-spacing py-5">
+  <div class="container">
+    {% assign guide_posts = paginator.posts %}
+    <div id="setupGuidesResults" class="row g-4">
+      {% for post in guide_posts %}
+        <div class="col-md-6 guide-card-item"
+             data-search="{{ post.title | downcase }} {{ post.excerpt | strip_html | downcase }} {{ post.tags | join: ' ' | downcase }}">
+          <article class="feature-card h-100 p-4">
+            <div class="d-flex justify-content-between align-items-start mb-2 gap-2">
+              <span class="badge badge-soft-primary">{{ post.date | date: "%b %d, %Y" }}</span>
+              {% if post.tags and post.tags.size > 0 %}
+                <div class="text-end">
+                  {% for tag in post.tags limit: 2 %}
+                    <span class="badge text-bg-light border">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+            <h2 class="h4 fw-bold mb-2">{{ post.title }}</h2>
+            <p class="text-muted mb-4">{{ post.excerpt | strip_html | truncate: 160 }}</p>
+            <a href="{{ post.url }}" class="btn btn-gradient btn-sm px-3">Read guide</a>
+          </article>
+        </div>
+      {% endfor %}
+    </div>
+
+    <p id="setupGuidesNoResults" class="text-muted text-center mt-4 d-none">No setup guides match your search on this page.</p>
+
+    {% if paginator.total_pages > 1 %}
+      <nav class="mt-5" aria-label="Setup guides pagination">
+        <ul class="pagination justify-content-center flex-wrap gap-2">
+          {% if paginator.previous_page %}
+            <li class="page-item">
+              <a class="page-link rounded-pill px-3" href="{{ paginator.previous_page_path }}">&laquo; Previous</a>
+            </li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link rounded-pill px-3">&laquo; Previous</span></li>
+          {% endif %}
+
+          {% for page in (1..paginator.total_pages) %}
+            {% if page == paginator.page %}
+              <li class="page-item active"><span class="page-link rounded-pill px-3">{{ page }}</span></li>
+            {% elsif page == 1 %}
+              <li class="page-item"><a class="page-link rounded-pill px-3" href="{{ '/support/setup-guides/' | relative_url }}">{{ page }}</a></li>
+            {% else %}
+              <li class="page-item"><a class="page-link rounded-pill px-3" href="{{ '/support/setup-guides/page/' | append: page | append: '/' | relative_url }}">{{ page }}</a></li>
+            {% endif %}
+          {% endfor %}
+
+          {% if paginator.next_page %}
+            <li class="page-item">
+              <a class="page-link rounded-pill px-3" href="{{ paginator.next_page_path }}">Next &raquo;</a>
+            </li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link rounded-pill px-3">Next &raquo;</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a dedicated place for step-by-step setup guide articles using Jekyll posts so content can be authored as dated Markdown in `_posts` with front-matter tags. 
- Surface those guides under a new `Support` menu item (placed before About) as a logical location for help resources.
- Support site-native features like tags and pagination and a quick client-side search for better discoverability of guides.

### Description
- Added a `Support` top-level menu and nested `Setup Guides` entry in `_data/menu.yml` to show the new landing page in navigation. 
- Enabled `jekyll-paginate-v2` in `Gemfile` and `_config.yml` and added `paginate_path` and a `posts` default so files in `_posts` use the `post` layout by default. 
- Added a Setup Guides landing page at `support/setup-guides/index.html` that uses pagination (`paginator.posts`), displays tags/excerpts, and renders pagination controls. 
- Created a `post` layout at `_layouts/post.html`, added a sample guide in `_posts/2026-04-17-basic-pa-setup-checklist.md`, updated `assets/js/main.js` to provide client-side search for the current page, and extended `assets/css/main.scss` with themed styles for pagination and post content. 

### Testing
- Verified YAML parse for site config and menu with `ruby -e 'require "yaml"; YAML.load_file("_config.yml"); YAML.load_file("_data/menu.yml"); puts "YAML OK"'` which succeeded. 
- Validated front matter parsing for posts with `ruby -e 'require "yaml"; Dir["_posts/*.md"].each{ |f| fm=File.read(f).split("---")[1]; YAML.safe_load(fm, permitted_classes: [Time]); }; puts "Front matter OK"'` which succeeded. 
- Attempted `bundle exec jekyll build` to verify the site output, but the environment failed to install required gems and `bundle install` returned errors due to a `403 Forbidden` from `rubygems.org`, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19db8b414832c912066a39f16b439)