### PR TITLE
Remove duplicate Bootstrap Icons include from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,3 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 <footer class="site-footer text-light">
   <div class="footer-top">
     <div class="container">


### PR DESCRIPTION
### Motivation
- Avoid inconsistent icon rendering and an extra stylesheet request by standardizing the Bootstrap Icons include to the layout-provided version (`1.11.3`) and removing the footer-injected `1.10.5` link.

### Description
- Deleted the Bootstrap Icons `<link>` tag from `_includes/footer.html` that referenced `https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css` so pages rely on the layout include.

### Testing
- Verified remaining references with `rg -n "bootstrap-icons" _layouts _includes` and inspected the change with `git diff -- _includes/footer.html`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41c61ac8c832c98e8e2be0814f520)