### PR TITLE
Unify Bootstrap source of truth to npm + Jekyll Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 # gem "rails"
 gem "jekyll"
-gem 'bootstrap', '~> 5.3.3'
 gem 'jekyll-seo-tag'
 
 gem 'jekyll-paginate-v2'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ cd your-repo
 npm install bootstrap
 ```
 
+
+## Bootstrap strategy (single source of truth)
+
+This project uses **Bootstrap from npm** and compiles it through the Jekyll Sass pipeline via `assets/css/main.scss` (`@import "bootstrap/scss/bootstrap"`).
+
+- Do **not** include Bootstrap CSS from a CDN in layouts.
+- Keep Bootstrap in `package.json` and let Jekyll compile `assets/css/main.css`.
+
 ## 3. Make changes to the repo
 
 Edit your files as needed.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,12 +39,6 @@
       rel="stylesheet"
     />
 
-    <!-- Bootstrap CSS -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
-
     <!-- Bootstrap Icons -->
     <link
       rel="stylesheet"

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -39,9 +39,6 @@
       rel="stylesheet"
     />
 
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
-
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
 


### PR DESCRIPTION
### Motivation
- The site previously mixed Bootstrap from multiple sources (npm Sass import, CDN CSS, and a Ruby gem), creating version drift and CSS precedence surprises. 
- Establishing a single canonical pipeline (`npm` -> Jekyll Sass -> compiled `assets/css/main.css`) makes builds deterministic and simplifies upgrades. 
- Removing duplicate sources reduces debugging surface when styles diverge after dependency updates.

### Description
- Removed Bootstrap CSS CDN `<link>` tags from `_layouts/default.html` and `_layouts/package.html` so pages rely on the compiled site stylesheet. 
- Removed the `bootstrap` Ruby gem entry from `Gemfile` to avoid dual package-manager sources for Bootstrap. 
- Left `package.json` and `assets/css/main.scss` using the npm `bootstrap` package and the Sass import (`@import "bootstrap/scss/bootstrap"`) as the canonical source. 
- Documented the strategy in `README.md` with guidance to use `npm` + the Jekyll Sass pipeline and not include CDN CSS in layouts.

### Testing
- Searched the repo for Bootstrap references using the pattern search and confirmed the CDN CSS includes were removed and the Sass import remains (`rg` search succeeded). 
- Verified `package.json` still contains the `bootstrap` dependency and `assets/css/main.scss` imports the npm Bootstrap source (`rg` checks). 
- Attempted `bundle exec jekyll build` in this environment but it failed with "command not found: jekyll" because Bundler dependencies are not installed here, so a full local build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e420a1db90832c8d1069de14720ee2)