### PR TITLE
Add CI quality gates: Jekyll build, HTMLProofer, and SCSS lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Lint SCSS (fail-fast)
+        run: npm run lint:scss
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+
+      - name: Run HTMLProofer
+        run: bundle exec htmlproofer ./_site --disable-external --enforce-https --check-html

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard-scss"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem "jekyll"
 gem 'jekyll-seo-tag'
 
 gem 'jekyll-paginate-v2'
+gem 'html-proofer'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint:scss": "stylelint \"assets/css/**/*.scss\" --allow-empty-input",
+    "test": "npm run lint:scss"
   },
   "repository": {
     "type": "git",
@@ -19,5 +20,10 @@
   "homepage": "https://github.com/vproaudio/vproaudio.github.io#readme",
   "dependencies": {
     "bootstrap": "^5.3.8"
+  },
+  "devDependencies": {
+    "stylelint": "^16.24.0",
+    "stylelint-config-standard-scss": "^14.0.0",
+    "stylelint-scss": "^6.12.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent link/HTML regressions and markup issues from shipping by running automated checks after builds.
- Fail fast on style problems so SCSS issues are caught before the site build proceeds.
- Ensure the Jekyll site actually builds in CI to catch build-time regressions.

### Description
- Add a GitHub Actions workflow at `/.github/workflows/ci.yml` that sets up Ruby and Node, runs `npm install`, executes SCSS linting (`npm run lint:scss`) first, then runs `bundle exec jekyll build`, and finally runs `bundle exec htmlproofer ./_site --disable-external --enforce-https --check-html`.
- Add `html-proofer` to the `Gemfile` to enable HTML/link checking in CI via Ruby gems.
- Add SCSS linting scripts and dev dependencies to `package.json` including `stylelint`, `stylelint-config-standard-scss`, and `stylelint-scss`, and add the `lint:scss` script wired into `test`.
- Add a Stylelint config file `.stylelintrc.json` that extends `stylelint-config-standard-scss`.

### Testing
- Ran `npm install` to validate Node dependencies, which failed with HTTP 403 from the npm registry so dev dependencies could not be installed.
- Ran `bundle lock` to validate Ruby dependencies, which failed with HTTP 403 from rubygems.org so `html-proofer` could not be resolved locally.
- No CI workflow run was executed here; CI is configured to run these checks on pushes to `main` and on pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e423bf0a14832c98aa19f34e49cd81)