### PR TITLE
Replace TikTok social links/icons with YouTube channel @VProAudioRentals

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ seo:
 social:
   name: "VANS Pro Audio Rentals"
   links:
-    - "https://www.tiktok.com/@vproaudiorentals"
+    - "https://www.youtube.com/@VProAudioRentals"
 
 exclude:
   - Gemfile
@@ -64,4 +64,3 @@ pagination:
   category: setup-guides
   per_page: 6
   permalink: /support/setup-guides/page/:num/
-

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -50,8 +50,8 @@
           <h6 class="footer-heading">Stay Connected</h6>
           <p class="footer-description small mb-3">Follow along for behind-the-scenes setups, gear drops, and rental inspiration.</p>
           <div class="footer-social d-flex align-items-center gap-3 mb-4">
-            <a href="https://www.tiktok.com/@vproaudiorentals" target="_blank" rel="noreferrer" class="footer-social-link" aria-label="TikTok">
-              <i class="bi bi-tiktok"></i>
+            <a href="https://www.youtube.com/@VProAudioRentals" target="_blank" rel="noreferrer" class="footer-social-link" aria-label="YouTube">
+              <i class="bi bi-youtube"></i>
             </a>
             <a href="mailto:bookings@vproaudio.rentals" class="footer-social-link" aria-label="Email">
               <i class="bi bi-envelope-fill"></i>

--- a/contact.html
+++ b/contact.html
@@ -67,8 +67,8 @@ permalink: /about/contact/
                                 <div>
                                     <h5 class="text-white">Follow our behind-the-scenes</h5>
                                     <p class="text-white-50 mb-3">Catch gear showcases, setup tutorials, and rental inspo.</p>
-                                    <a href="https://www.tiktok.com/@vproaudiorentals" target="_blank" class="btn btn-outline-light btn-sm px-3 d-inline-flex align-items-center gap-2">
-                                        <i class="bi bi-tiktok"></i> TikTok @vproaudiorentals
+                                    <a href="https://www.youtube.com/@VProAudioRentals" target="_blank" class="btn btn-outline-light btn-sm px-3 d-inline-flex align-items-center gap-2">
+                                        <i class="bi bi-youtube"></i> YouTube @VProAudioRentals
                                     </a>
                                 </div>
                             </div>
@@ -172,4 +172,3 @@ permalink: /about/contact/
         </div>
     </div>
 </section>
-

--- a/index.html
+++ b/index.html
@@ -198,9 +198,9 @@ title: Home
 <section class="section-spacing text-center">
   <div class="container">
     <h2 class="display-6 fw-bold mb-3">See our gear in action</h2>
-    <p class="lead text-muted mb-4">Follow us on TikTok <a href="https://www.tiktok.com/@vproaudiorentals" target="_blank" class="text-decoration-none">@vproaudiorentals</a></p>
+    <p class="lead text-muted mb-4">Follow us on YouTube <a href="https://www.youtube.com/@VProAudioRentals" target="_blank" class="text-decoration-none">@VProAudioRentals</a></p>
     <div class="social-highlight d-inline-flex align-items-center gap-3 px-4 py-3 shadow-sm rounded-4">
-      <i class="bi bi-tiktok fs-3 text-primary"></i>
+      <i class="bi bi-youtube fs-3 text-primary"></i>
       <span class="fw-semibold">Weekly behind-the-scenes drops &amp; gear tips</span>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Direct users to the project's YouTube channel `@VProAudioRentals` instead of TikTok and keep social CTAs, icons, and metadata consistent across the site.

### Description
- Updated the homepage social proof block in `index.html` to mention YouTube and swap the icon to `bi-youtube` linking to `https://www.youtube.com/@VProAudioRentals`.
- Replaced the TikTok CTA button in `contact.html` with a YouTube button and the `bi-youtube` icon linking to `https://www.youtube.com/@VProAudioRentals`.
- Updated the footer include ` _includes/footer.html` to use the YouTube link, `bi-youtube` icon, and adjusted the `aria-label` to "YouTube".
- Updated the site social metadata in `_config.yml` to point the `social.links` entry to `https://www.youtube.com/@VProAudioRentals`.

### Testing
- Ran `rg -n "tiktok|TikTok" index.html contact.html _includes/footer.html _config.yml` and confirmed there are no remaining TikTok references (success).
- Verified working tree state with `git status --short` after changes and committed the updates (no outstanding changes remaining).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a8628274832c9e604ac85d423d44)