### PR TITLE
Group package menus under one header dropdown

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,27 +1,28 @@
 - title: Home
   url: /
 
-- title: Event Audio
+- title: Packages
   dropdown:
-    - title: Backyard Event Sound System
-      url: /packages/event-audio/backyard-event-sound-system/
-    - title: Wedding Ceremony Audio System
-      url: /packages/event-audio/wedding-ceremony-audio-system/
-    - title: Ceremony + Cocktail Hour
-      url: /packages/event-audio/ceremony-plus-cocktail-hour/
-    - title: Wedding Reception Sound System
-      url: /packages/event-audio/wedding-reception-sound-system/
-    - title: Corporate Presentation Package
-      url: /packages/event-audio/corporate-presentation-package/
-    - title: Celebration of Life AV Package
-      url: /packages/event-audio/celebration-of-life-av-package/
-
-- title: Party Audio
-  dropdown:
-    - title: Party Speaker Package
-      url: /packages/party-audio/party-speaker-package/
-    - title: Karaoke & Party Pack
-      url: /packages/party-audio/karaoke-and-party-pack/
+    - title: Event Audio
+      dropdown:
+        - title: Backyard Event Sound System
+          url: /packages/event-audio/backyard-event-sound-system/
+        - title: Wedding Ceremony Audio System
+          url: /packages/event-audio/wedding-ceremony-audio-system/
+        - title: Ceremony + Cocktail Hour
+          url: /packages/event-audio/ceremony-plus-cocktail-hour/
+        - title: Wedding Reception Sound System
+          url: /packages/event-audio/wedding-reception-sound-system/
+        - title: Corporate Presentation Package
+          url: /packages/event-audio/corporate-presentation-package/
+        - title: Celebration of Life AV Package
+          url: /packages/event-audio/celebration-of-life-av-package/
+    - title: Party Audio
+      dropdown:
+        - title: Party Speaker Package
+          url: /packages/party-audio/party-speaker-package/
+        - title: Karaoke & Party Pack
+          url: /packages/party-audio/karaoke-and-party-pack/
 
 - title: Support
   dropdown:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,8 +25,16 @@
         {% for item in site.data.menu %}
           {% if item.dropdown %}
             {% assign active = false %}
+            {% assign has_nested = false %}
             {% for sub in item.dropdown %}
-              {% if page.url == sub.url %}
+              {% if sub.dropdown %}
+                {% assign has_nested = true %}
+                {% for child in sub.dropdown %}
+                  {% if page.url == child.url %}
+                    {% assign active = true %}
+                  {% endif %}
+                {% endfor %}
+              {% elsif page.url == sub.url %}
                 {% assign active = true %}
               {% endif %}
             {% endfor %}
@@ -40,10 +48,39 @@
               >
                 {{ item.title }}
               </a>
-              <ul class="dropdown-menu shadow-sm border-0 rounded-3 overflow-hidden">
+              <ul class="dropdown-menu main-dropdown-menu shadow-sm border-0 rounded-3{% unless has_nested %} overflow-hidden{% endunless %}">
                 {% for sub in item.dropdown %}
                   {% if sub.divider %}
                     <li><hr class="dropdown-divider"></li>
+                  {% elsif sub.dropdown %}
+                    {% assign sub_active = false %}
+                    {% for child in sub.dropdown %}
+                      {% if page.url == child.url %}
+                        {% assign sub_active = true %}
+                      {% endif %}
+                    {% endfor %}
+                    <li class="dropend package-submenu">
+                      <button
+                        class="dropdown-item dropdown-toggle package-submenu-toggle {% if sub_active %}active{% endif %}"
+                        type="button"
+                        aria-expanded="false"
+                      >
+                        {{ sub.title }}
+                      </button>
+                      <ul class="dropdown-menu nested-dropdown-menu shadow-sm border-0 rounded-3 overflow-hidden">
+                        {% for child in sub.dropdown %}
+                          {% if child.divider %}
+                            <li><hr class="dropdown-divider"></li>
+                          {% else %}
+                            <li>
+                              <a class="dropdown-item {% if page.url == child.url %}active{% endif %}" href="{{ child.url }}">
+                                {{ child.title }}
+                              </a>
+                            </li>
+                          {% endif %}
+                        {% endfor %}
+                      </ul>
+                    </li>
                   {% else %}
                     <li>
                       <a class="dropdown-item {% if page.url == sub.url %}active{% endif %}" href="{{ sub.url }}">

--- a/_sass/theme/_components.scss
+++ b/_sass/theme/_components.scss
@@ -443,3 +443,56 @@
   position: relative;
   z-index: 1;
 }
+
+.main-dropdown-menu {
+  min-width: 16rem;
+}
+
+.package-submenu {
+  position: relative;
+}
+
+.package-submenu-toggle {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.package-submenu-toggle::after {
+  margin-left: auto;
+}
+
+@media (width >= 992px) {
+  .package-submenu > .nested-dropdown-menu {
+    display: none;
+    left: 100%;
+    margin-left: 0.25rem;
+    margin-top: -0.35rem;
+    min-width: 18rem;
+    position: absolute;
+    top: 0;
+  }
+
+  .package-submenu:hover > .nested-dropdown-menu,
+  .package-submenu:focus-within > .nested-dropdown-menu,
+  .package-submenu.show > .nested-dropdown-menu {
+    display: block;
+  }
+}
+
+@media (width < 992px) {
+  .package-submenu > .nested-dropdown-menu {
+    border-left: 2px solid rgba(t.$primary, 0.12) !important;
+    box-shadow: none !important;
+    display: none;
+    float: none;
+    margin: 0.25rem 0 0.5rem 1rem;
+    position: static;
+  }
+
+  .package-submenu.show > .nested-dropdown-menu {
+    display: block;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,6 +2,41 @@
 console.log('Bootstrap + Jekyll loaded!');
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Nested package dropdowns
+  const packageSubmenuToggles = document.querySelectorAll('.package-submenu-toggle');
+
+  packageSubmenuToggles.forEach((toggle) => {
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const submenuItem = toggle.closest('.package-submenu');
+      if (!submenuItem) return;
+
+      const siblingSubmenus = submenuItem.parentElement.querySelectorAll('.package-submenu.show');
+      siblingSubmenus.forEach((sibling) => {
+        if (sibling !== submenuItem) {
+          sibling.classList.remove('show');
+          const siblingToggle = sibling.querySelector('.package-submenu-toggle');
+          if (siblingToggle) siblingToggle.setAttribute('aria-expanded', 'false');
+        }
+      });
+
+      const isOpen = submenuItem.classList.toggle('show');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+  });
+
+  document.querySelectorAll('.nav-item.dropdown').forEach((dropdown) => {
+    dropdown.addEventListener('hidden.bs.dropdown', () => {
+      dropdown.querySelectorAll('.package-submenu.show').forEach((submenu) => {
+        submenu.classList.remove('show');
+        const toggle = submenu.querySelector('.package-submenu-toggle');
+        if (toggle) toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  });
+
   // Setup guides filtering
   const setupGuidesSearchInput = document.getElementById('setupGuidesSearch');
   const setupGuidesCards = Array.from(document.querySelectorAll('.guide-card-item'));


### PR DESCRIPTION
### Motivation
- Consolidate separate Event Audio and Party Audio top-level navigation entries into a single, organized Packages menu for better discoverability and a cleaner header.
- Provide nested category navigation so clicking Packages reveals Event Audio and Party Audio, and those categories open their package lists to the side on desktop and inline on mobile.

### Description
- Reworked `_data/menu.yml` to replace the separate Event Audio and Party Audio items with a single `Packages` item and nested `Event Audio` and `Party Audio` submenus. 
- Updated `_includes/header.html` to render nested dropdowns, preserve active states for parent/category items, and output a two-level menu with button-controlled nested lists. 
- Added styles in `_sass/theme/_components.scss` to layout `.main-dropdown-menu` and `.nested-dropdown-menu` so submenus appear as side menus on desktop and inline on smaller screens. 
- Added client-side behavior in `assets/js/main.js` to toggle nested category menus (`.package-submenu-toggle`), close sibling submenus, and reset nested state when dropdowns close.

### Testing
- Ran `npm test` (stylelint) after adjustments and the lint run passed (initial style issues were addressed). 
- Verified menu YAML parsing with `ruby -e 'require "yaml"; YAML.load_file("_data/menu.yml")'` which succeeded. 
- Built Sass with `npm run sass:build` which completed successfully while emitting existing Sass/Bootstrap deprecation warnings. 
- Attempted full site build with `npm run build` but `bundle install` / `bundle exec jekyll build` were blocked in this environment because Bundler failed to fetch gems from rubygems.org (HTTP 403), so the Jekyll build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e8a34b78832c9c96bb392dd93831)