### PR TITLE
Header: Only highlight top-level menu for active pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,11 +30,11 @@
               {% if sub.dropdown %}
                 {% assign has_nested = true %}
                 {% for child in sub.dropdown %}
-                  {% if page.url == child.url %}
+                  {% if page.url == child.url or page.url contains child.url %}
                     {% assign active = true %}
                   {% endif %}
                 {% endfor %}
-              {% elsif page.url == sub.url %}
+              {% elsif page.url == sub.url or page.url contains sub.url %}
                 {% assign active = true %}
               {% endif %}
             {% endfor %}
@@ -53,15 +53,9 @@
                   {% if sub.divider %}
                     <li><hr class="dropdown-divider"></li>
                   {% elsif sub.dropdown %}
-                    {% assign sub_active = false %}
-                    {% for child in sub.dropdown %}
-                      {% if page.url == child.url %}
-                        {% assign sub_active = true %}
-                      {% endif %}
-                    {% endfor %}
                     <li class="dropend package-submenu">
                       <button
-                        class="dropdown-item dropdown-toggle package-submenu-toggle {% if sub_active %}active{% endif %}"
+                        class="dropdown-item dropdown-toggle package-submenu-toggle"
                         type="button"
                         aria-expanded="false"
                       >
@@ -73,7 +67,7 @@
                             <li><hr class="dropdown-divider"></li>
                           {% else %}
                             <li>
-                              <a class="dropdown-item {% if page.url == child.url %}active{% endif %}" href="{{ child.url }}">
+                              <a class="dropdown-item" href="{{ child.url }}">
                                 {{ child.title }}
                               </a>
                             </li>
@@ -83,7 +77,7 @@
                     </li>
                   {% else %}
                     <li>
-                      <a class="dropdown-item {% if page.url == sub.url %}active{% endif %}" href="{{ sub.url }}">
+                      <a class="dropdown-item" href="{{ sub.url }}">
                         {{ sub.title }}
                       </a>
                     </li>


### PR DESCRIPTION
### Motivation
- Ensure a top-level header menu item (e.g., `Support`) is highlighted when any page under its subtree (such as setup guide detail pages) is active, while preventing dropdown sub-menus and individual dropdown items from receiving the active highlight.

### Description
- Updated active-state detection in `_includes/header.html` to treat descendant URLs as matches by checking `page.url contains child.url` and `page.url contains sub.url` so parent dropdowns become active for nested pages.
- Removed the `active` class from nested submenu toggles and individual dropdown-item anchors so only the topmost header item shows the active state.
- Eliminated the per-submenu `sub_active` evaluation since submenu items no longer receive the active styling.
- Committed changes to `_includes/header.html` and opened the PR titled accordingly.

### Testing
- Ran `npm test` (SCSS lint) which completed successfully.
- Ran `npm run sass:build` which completed successfully but emitted Sass deprecation warnings from Bootstrap imports.
- Attempted `bundle exec jekyll build` but it was blocked because the `jekyll` executable was not available (`bundle install` failed due to RubyGems `403 Forbidden`).
- Attempted runtime Liquid parsing with `ruby -e "require 'liquid' ..."` but it was blocked due to the `liquid` gem being unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05eded8584832c884cdf0f1c771f71)