### PR TITLE
Fix nested package menu overlap

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,25 +5,40 @@ document.addEventListener('DOMContentLoaded', () => {
   // Nested package dropdowns
   const packageSubmenuToggles = document.querySelectorAll('.package-submenu-toggle');
 
+  const closeSiblingPackageSubmenus = (submenuItem) => {
+    if (!submenuItem || !submenuItem.parentElement) return;
+
+    const siblingSubmenus = submenuItem.parentElement.querySelectorAll('.package-submenu.show');
+    siblingSubmenus.forEach((sibling) => {
+      if (sibling !== submenuItem) {
+        sibling.classList.remove('show');
+        const siblingToggle = sibling.querySelector('.package-submenu-toggle');
+        if (siblingToggle) siblingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  };
+
   packageSubmenuToggles.forEach((toggle) => {
+    const submenuItem = toggle.closest('.package-submenu');
+
     toggle.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
 
-      const submenuItem = toggle.closest('.package-submenu');
       if (!submenuItem) return;
 
-      const siblingSubmenus = submenuItem.parentElement.querySelectorAll('.package-submenu.show');
-      siblingSubmenus.forEach((sibling) => {
-        if (sibling !== submenuItem) {
-          sibling.classList.remove('show');
-          const siblingToggle = sibling.querySelector('.package-submenu-toggle');
-          if (siblingToggle) siblingToggle.setAttribute('aria-expanded', 'false');
-        }
-      });
+      closeSiblingPackageSubmenus(submenuItem);
 
       const isOpen = submenuItem.classList.toggle('show');
       toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+
+    toggle.addEventListener('mouseenter', () => {
+      closeSiblingPackageSubmenus(submenuItem);
+    });
+
+    toggle.addEventListener('focusin', () => {
+      closeSiblingPackageSubmenus(submenuItem);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Nested package submenus (e.g. “Event Audio” / “Party Audio”) could remain open in the background and other nested menus would open on top of them, causing visual overlap and confusing interaction.
- Ensure only the active nested submenu is visible when opening, hovering, or keyboard-focusing another submenu.

### Description
- Added a shared helper `closeSiblingPackageSubmenus` in `assets/js/main.js` that closes any sibling `.package-submenu.show` and resets their `aria-expanded` state. 
- Moved `submenuItem` resolution out of the click handler and reuse it per toggle to avoid redundant lookups. 
- Invoke the sibling-close helper on `click`, `mouseenter`, and `focusin` for `.package-submenu-toggle` so switching between nested submenus always closes others.
- Kept existing behavior that fully closes nested submenus when the parent `nav-item.dropdown` is hidden by listening to `hidden.bs.dropdown`.

### Testing
- Ran `node --check assets/js/main.js` which passed with no syntax errors. 
- Ran `git diff --check` which passed with no whitespace or diff issues. 
- Ran `npm test` (stylelint for SCSS) which passed (lint completed). 
- Ran `npm run build` where the Sass phase completed but `bundle exec jekyll build` could not run because the local bundle did not expose `jekyll` (build halted). 
- Ran `bundle install` which failed due to `403 Forbidden` fetching gems from rubygems.org, preventing a full site build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f1f83aa4832cbc693420ead29d0e)