### PR TITLE
Improve nested package submenu behavior and desktop hover handling

### DIFF
--- a/_sass/theme/_components.scss
+++ b/_sass/theme/_components.scss
@@ -475,9 +475,7 @@
     top: 0;
   }
 
-  .package-submenu:hover > .nested-dropdown-menu,
-  .package-submenu:focus-within > .nested-dropdown-menu,
-  .package-submenu.show > .nested-dropdown-menu {
+  .package-submenu:hover > .nested-dropdown-menu {
     display: block;
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,27 +4,64 @@ console.log('Bootstrap + Jekyll loaded!');
 document.addEventListener('DOMContentLoaded', () => {
   // Nested package dropdowns
   const packageSubmenuToggles = document.querySelectorAll('.package-submenu-toggle');
+  const desktopPackageSubmenuQuery = window.matchMedia('(min-width: 992px)');
+
+  const closePackageSubmenu = (submenuItem) => {
+    if (!submenuItem) return;
+
+    submenuItem.classList.remove('show');
+    const toggle = submenuItem.querySelector('.package-submenu-toggle');
+    if (toggle) toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  const closeSiblingPackageSubmenus = (submenuItem) => {
+    if (!submenuItem || !submenuItem.parentElement) return;
+
+    const siblingSubmenus = submenuItem.parentElement.querySelectorAll('.package-submenu.show');
+    siblingSubmenus.forEach((sibling) => {
+      if (sibling !== submenuItem) closePackageSubmenu(sibling);
+    });
+  };
+
+  const closeAllPackageSubmenus = () => {
+    document.querySelectorAll('.package-submenu.show').forEach(closePackageSubmenu);
+  };
 
   packageSubmenuToggles.forEach((toggle) => {
+    const submenuItem = toggle.closest('.package-submenu');
+
     toggle.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
 
-      const submenuItem = toggle.closest('.package-submenu');
       if (!submenuItem) return;
 
-      const siblingSubmenus = submenuItem.parentElement.querySelectorAll('.package-submenu.show');
-      siblingSubmenus.forEach((sibling) => {
-        if (sibling !== submenuItem) {
-          sibling.classList.remove('show');
-          const siblingToggle = sibling.querySelector('.package-submenu-toggle');
-          if (siblingToggle) siblingToggle.setAttribute('aria-expanded', 'false');
-        }
-      });
+      closeSiblingPackageSubmenus(submenuItem);
+
+      if (desktopPackageSubmenuQuery.matches) {
+        closePackageSubmenu(submenuItem);
+        toggle.blur();
+        return;
+      }
 
       const isOpen = submenuItem.classList.toggle('show');
       toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     });
+
+    toggle.addEventListener('mouseenter', () => {
+      if (!desktopPackageSubmenuQuery.matches || !submenuItem) return;
+
+      closeSiblingPackageSubmenus(submenuItem);
+      toggle.setAttribute('aria-expanded', 'true');
+    });
+
+    toggle.addEventListener('mouseleave', () => {
+      if (desktopPackageSubmenuQuery.matches) toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+
+  desktopPackageSubmenuQuery.addEventListener('change', (event) => {
+    if (event.matches) closeAllPackageSubmenus();
   });
 
   document.querySelectorAll('.nav-item.dropdown').forEach((dropdown) => {


### PR DESCRIPTION
### Motivation
- Fix inconsistent nested package submenu behavior across desktop and mobile and improve keyboard/ARIA state management.
- Prevent JS-driven `.show` state from forcing nested menus open at desktop sizes so hover is the primary display control on wide viewports.

### Description
- Remove `.package-submenu:focus-within` and `.package-submenu.show` display rules from the desktop media query in `_components.scss` so nested menus at `min-width: 992px` only open on hover via CSS.
- Add responsive JS using `window.matchMedia('(min-width: 992px)')` and helper functions `closePackageSubmenu`, `closeSiblingPackageSubmenus`, and `closeAllPackageSubmenus` in `assets/js/main.js` to centralize submenu closing logic.
- Update click handler to keep mobile toggle behavior but to close and blur the toggle on desktop instead of toggling the `.show` state, and keep `aria-expanded` synchronized when toggles open/close.
- Add `mouseenter`/`mouseleave` handlers to set `aria-expanded` and close sibling submenus on desktop, and listen for breakpoint changes to close all submenus when switching viewports.

### Testing
- No automated tests were added for this change and no automated test run was performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f1f83aa4832cbc693420ead29d0e)