### PR TITLE
Footer: show underline on hover and hide by default

### DIFF
--- a/_sass/theme/_base.scss
+++ b/_sass/theme/_base.scss
@@ -100,12 +100,12 @@ footer.site-footer {
 
   a {
     color: rgba(#fff, 0.88);
+    text-decoration: none;
     transition: color 0.2s ease, transform 0.2s ease;
 
     &:hover,
     &:focus {
       color: #fff;
-      text-decoration: none;
     }
   }
 
@@ -207,6 +207,14 @@ footer.site-footer {
     small {
       color: rgba(#fff, 0.6);
       font-weight: 500;
+    }
+  }
+
+  .footer-contact a,
+  .footer-links a {
+    &:hover,
+    &:focus {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Footer links were underlined by default and removed on hover; the intent is to invert this so that links are clean by default and underline only when hovered or focused for clearer UX affordance.

### Description
- Updated `_sass/theme/_base.scss` to set `footer.site-footer a` to `text-decoration: none` so footer anchors are not underlined by default. 
- Added hover/focus underline for footer contact and navigation links via `.footer-contact a, .footer-links a { &:hover, &:focus { text-decoration: underline; } }` so underline appears on hover. 
- No markup changes were required in the final version; styles scoped to the footer only.

### Testing
- Ran `npm run lint:scss` and the SCSS lint checks completed successfully. 
- Ran `npm run sass:build` and the CSS was produced (Sass emitted deprecation warnings but build completed). 
- Ran `npm run build` which runs Sass build and `bundle exec jekyll build`, and the Sass step completed while `bundle exec jekyll build` failed in this environment because the `jekyll` executable is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060841b37c832c8955513f2fd5ed32)